### PR TITLE
This fixes a crash bug when switching between RTLSDR and USRP devices

### DIFF
--- a/applications/gqrx/receiver.cpp
+++ b/applications/gqrx/receiver.cpp
@@ -436,7 +436,13 @@ receiver::status receiver::get_gain_range(std::string &name, double *start, doub
 
 receiver::status receiver::set_gain(std::string name, double value)
 {
-    src->set_gain(value, name);
+    try {
+	    src->set_gain(value, name);
+    }
+    catch (std::runtime_error &e) {
+      std::cout << "Error changing gain for " << name << " to " << value << ": " << e.what() << std::endl;
+      return STATUS_ERROR;
+    }
 
     return STATUS_OK;
 }


### PR DESCRIPTION
When the RTLSDR is successfully used, and then the user switches over to their USRP device, gqrx starts a crash loop that cannot be escaped without deleting a line in your default.conf.

This change modifies the receiver.cpp to catch the exception when an invalid gain type is set via osmosdr, and fails with an error message.

I believe this to be the proper behavior.

This PR should fix https://github.com/csete/gqrx/issues/125