### PR TITLE
bookmark utf8 read bug fix

### DIFF
--- a/qtgui/bookmarks.cpp
+++ b/qtgui/bookmarks.cpp
@@ -85,7 +85,7 @@ bool Bookmarks::load()
         // Read Tags, until first empty line.
         while (!file.atEnd())
         {
-            QString line = file.readLine().trimmed();
+            QString line = QString::fromUtf8(file.readLine().trimmed());
 
             if(line.isEmpty())
                 break;
@@ -108,7 +108,7 @@ bool Bookmarks::load()
         // Read Bookmarks, after first empty line.
         while (!file.atEnd())
         {
-            QString line = file.readLine().trimmed();
+            QString line = QString::fromUtf8(file.readLine().trimmed());
             if(line.isEmpty() || line.startsWith("#"))
                 continue;
 


### PR DESCRIPTION
Bookmarks have a bug with reading utf-8 text - they obviously treated as ascii and displayed improperly. This request fixing the problem. 