### PR TITLE
Fix AGC complex

### DIFF
--- a/dsp/agc_impl.h
+++ b/dsp/agc_impl.h
@@ -72,6 +72,8 @@ private:
     int         m_HangTimer;
 
     TYPECPX     m_SigDelayBuf[MAX_DELAY_BUF];
+    float*      m_SigDelayBuf_r;
+
     float       m_MagBuf[MAX_DELAY_BUF];
 };
 


### PR DESCRIPTION
Fixes issues with std::complex from commit 97da41ef in DSP/AGC. Works with GCC / libstdc++ as well as Clang / libc++, c++11 or prior. I avoid GCC-specific extensions to std::complex, such as "foo.real() = 1.0;". Please review the hack I used for the real-only version (using a pointer, which is set in the constructor); I see no reason it won't work -- it just uses contiguous memory for the real values instead of just the real() part of complex storage array.