### PR TITLE
Volk dependency

### DIFF
--- a/gqrx.pro
+++ b/gqrx.pro
@@ -225,7 +225,8 @@ PKGCONFIG += gnuradio-analog \
              gnuradio-digital \
              gnuradio-filter \
              gnuradio-fft \
-             gnuradio-osmosdr
+             gnuradio-osmosdr \
+             volk
 
 unix:!macx {
     LIBS += -lboost_system$$BOOST_SUFFIX -lboost_program_options$$BOOST_SUFFIX


### PR DESCRIPTION
Without this modification the linker complains:

```
/usr/bin/ld: warning: libvolk.so.1.0, needed by [...]/lib/libgnuradio-analog.so, not found (try using -rpath or -rpath-link)
```