### PR TITLE
Stereo separation improvement

### DIFF
--- a/dsp/stereo_demod.cpp
+++ b/dsp/stereo_demod.cpp
@@ -105,8 +105,8 @@ stereo_demod::stereo_demod(float input_rate, float audio_rate, bool stereo, bool
 
     mixer = gr::blocks::multiply_ff::make();
 
-    cdp = gr::blocks::multiply_const_ff::make( 2.); // FIXME
-    cdm = gr::blocks::multiply_const_ff::make(-2.); // FIXME
+    cdp = gr::blocks::multiply_const_ff::make( 5.5); // FIXME
+    cdm = gr::blocks::multiply_const_ff::make(-5.5); // FIXME
 
     add0 = gr::blocks::add_ff::make();
     add1 = gr::blocks::add_ff::make();


### PR DESCRIPTION
I've been experimenting with improving stereo separation on FM Stereo decoder as it is used here in Europe on 3m FM band. I've been able to separate channels more clearly, but this is so far based on my experience. YMMV. Also, stronger signal is probably needed for clear reception under this configuration.