### PR TITLE
Clean up compiler warnings.

### DIFF
--- a/applications/gqrx/receiver.cpp
+++ b/applications/gqrx/receiver.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <iostream>
 #include <unistd.h>
+#include <cstdlib>
 
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
@@ -513,22 +514,22 @@ receiver::status receiver::set_filter(double low, double high, filter_shape shap
 {
     double trans_width;
 
-    if ((low >= high) || (abs(high-low) < RX_FILTER_MIN_WIDTH))
+    if ((low >= high) || (std::abs(high-low) < RX_FILTER_MIN_WIDTH))
         return STATUS_ERROR;
 
     switch (shape) {
 
     case FILTER_SHAPE_SOFT:
-        trans_width = abs(high - low) * 0.4;
+        trans_width = std::abs(high - low) * 0.4;
         break;
 
     case FILTER_SHAPE_SHARP:
-        trans_width = abs(high - low) * 0.05;
+        trans_width = std::abs(high - low) * 0.05;
         break;
 
     case FILTER_SHAPE_NORMAL:
     default:
-        trans_width = abs(high - low) * 0.2;
+        trans_width = std::abs(high - low) * 0.2;
         break;
 
     }

--- a/applications/gqrx/receiver.cpp
+++ b/applications/gqrx/receiver.cpp
@@ -23,7 +23,6 @@
 #include <cmath>
 #include <iostream>
 #include <unistd.h>
-#include <cstdlib>
 
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>

--- a/applications/gqrx/remote_control.cpp
+++ b/applications/gqrx/remote_control.cpp
@@ -22,6 +22,7 @@
  */
 #include <QString>
 
+#include <cstdlib>
 #include "remote_control.h"
 
 RemoteControl::RemoteControl(QObject *parent) :
@@ -285,7 +286,7 @@ void RemoteControl::setNewRemoteFreq(qint64 freq)
 {
     qint64 delta = freq - rc_freq;
 
-    if (abs(rc_filter_offset + delta) < bw_half)
+    if (std::abs(rc_filter_offset + delta) < bw_half)
     {
         // move filter offset
         rc_filter_offset += delta;

--- a/qtgui/dockbookmarks.cpp
+++ b/qtgui/dockbookmarks.cpp
@@ -27,6 +27,8 @@
 #include <QComboBox>
 #include <QDialogButtonBox>
 
+#include <cstdlib>
+
 #include "bookmarks.h"
 #include "bookmarkstaglist.h"
 #include "dockbookmarks.h"
@@ -116,7 +118,7 @@ void DockBookmarks::setNewFrequency(qint64 rx_freq)
     for(int row=0; row<iRowCount; ++row)
     {
         BookmarkInfo& info = *(bookmarksTableModel->getBookmarkAtRow(row));
-        if( abs(rx_freq - info.frequency) <= ((info.bandwidth/2)+1) )
+        if( std::abs(rx_freq - info.frequency) <= ((info.bandwidth/2)+1) )
         {
             ui->tableViewFrequencyList->selectRow(row);
             ui->tableViewFrequencyList->scrollTo( ui->tableViewFrequencyList->currentIndex(), QAbstractItemView::EnsureVisible );
@@ -151,7 +153,7 @@ void DockBookmarks::on_tableWidgetTagList_itemChanged(QTableWidgetItem *item)
     if(ui->tableWidgetTagList->m_bUpdating) return;
 
     int col = item->column();
-    if(!col==1) return;
+    if(!(col==1)) return;
 
     QString strText = item->text();
     Bookmarks::Get().setTagChecked(strText, (item->checkState() == Qt::Checked));

--- a/qtgui/freqctrl.cpp
+++ b/qtgui/freqctrl.cpp
@@ -38,7 +38,6 @@
 //authors and should not be interpreted as representing official policies, either expressed
 //or implied, of Moe Wheatley.
 //==========================================================================================
-//#include <stdlib.h>
 
 #include <QDebug>
 #include "freqctrl.h"

--- a/qtgui/meter.cpp
+++ b/qtgui/meter.cpp
@@ -27,7 +27,7 @@
  * authors and should not be interpreted as representing official policies, either expressed
  * or implied, of Moe Wheatley.
  */
-#include <stdlib.h>
+#include <cstdlib>
 #include <QDebug>
 #include "meter.h"
 

--- a/qtgui/plotter.cpp
+++ b/qtgui/plotter.cpp
@@ -27,7 +27,7 @@
  * authors and should not be interpreted as representing official policies, either expressed
  * or implied, of Moe Wheatley.
  */
-#include <stdlib.h>
+#include <cstdlib>
 #include <cmath>
 #include <QDebug>
 #include <QtGlobal>
@@ -112,7 +112,7 @@ CPlotter::CPlotter(QWidget *parent) :
     m_VerDivs = 6;
     m_MaxdB = 0;
     m_MindB = -135;
-    m_dBStepSize = abs(m_MaxdB-m_MindB)/m_VerDivs;
+    m_dBStepSize = std::abs(m_MaxdB-m_MindB)/m_VerDivs;
 
     m_FreqUnits = 1000000;
     m_CursorCaptured = NONE;

--- a/receivers/nbrx.cpp
+++ b/receivers/nbrx.cpp
@@ -21,6 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 #include <iostream>
+#include <cstdlib>
 #include "receivers/nbrx.h"
 
 #define PREF_QUAD_RATE  48000.0
@@ -85,7 +86,7 @@ bool nbrx::stop()
 
 void nbrx::set_quad_rate(float quad_rate)
 {
-    if (abs(d_quad_rate-quad_rate) > 0.5)
+    if (std::abs(d_quad_rate-quad_rate) > 0.5)
     {
 #ifndef QT_NO_DEBUG_OUTPUT
         std::cout << "Changing NB_RX quad rate: "  << d_quad_rate << " -> " << quad_rate << std::endl;

--- a/receivers/wfmrx.cpp
+++ b/receivers/wfmrx.cpp
@@ -22,6 +22,7 @@
  * Boston, MA 02110-1301, USA.
  */
 #include <iostream>
+#include <cstdlib>
 #include "receivers/wfmrx.h"
 
 #define PREF_QUAD_RATE   240e3 // Nominal channel spacing is 200 kHz
@@ -89,7 +90,7 @@ bool wfmrx::stop()
 
 void wfmrx::set_quad_rate(float quad_rate)
 {
-    if (abs(d_quad_rate-quad_rate) > 0.5)
+    if (std::abs(d_quad_rate-quad_rate) > 0.5)
     {
 #ifndef QT_NO_DEBUG_OUTPUT
         std::cout << "Changing NB_RX quad rate: "  << d_quad_rate << " -> " << quad_rate << std::endl;


### PR DESCRIPTION
- Updated use of abs() to std::abs() to match parameter types.
- in docbookmarks.cpp:156, change !col==1 to !(col==1) which I believe is the intended behavior.