### PR TITLE
- fix compilation error. 

### DIFF
--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -22,6 +22,7 @@
  */
 #include <cmath>
 #include <QString>
+#include <cstdlib>
 #include "remote_control.h"
 
 RemoteControl::RemoteControl(QObject *parent) :

--- a/src/qtgui/dockbookmarks.cpp
+++ b/src/qtgui/dockbookmarks.cpp
@@ -21,6 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 #include <cmath>
+#include <cstdlib>
 #include <QDir>
 #include <QInputDialog>
 #include <QMessageBox>


### PR DESCRIPTION
Whereas math does define a std::abs(), the call is ambiguous (so says llvm, as a compile error.  Didn't notice this before.).  Including cstdlib disambiguates for some reason.  Could also type cast...