### PR TITLE
Fix use of std::complex variables

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1305,7 +1305,7 @@ void MainWindow::iqFftTimeout()
         }
 
         /* calculate power in dBFS */
-        pwr = pwr_scale * (pt.imag() * pt.imag() + pt.real() * pt.real());
+        pwr = pwr_scale * std::norm(pt);
         d_realFftData[i] = 10.0 * log10f(pwr + 1.0e-20);
 
         /* FFT averaging */
@@ -1353,7 +1353,7 @@ void MainWindow::audioFftTimeout()
         }
 
         /* calculate power in dBFS */
-        pwr = pwr_scale * (pt.imag() * pt.imag() + pt.real() * pt.real());
+        pwr = pwr_scale * std::norm(pt);
         d_realFftData[i] = 10.0 * log10f(pwr + 1.0e-20);
     }
 

--- a/src/dsp/filter/decimator.cpp
+++ b/src/dsp/filter/decimator.cpp
@@ -307,13 +307,9 @@ int Decimator::CHalfBand11TapDecimateBy2::DecBy2(int InLength,
 
     for(i = 0; i < (InLength - 11 - 6) / 2; i++)
 	{
-        (*pOut).real( H0 * pIn[0].real() + H2 * pIn[2].real()
-                + H4 * pIn[4].real() + H5 * pIn[5].real() + H6 * pIn[6].real()
-                + H8 * pIn[8].real() + H10 * pIn[10].real());
-        (*pOut++).imag( H0 * pIn[0].imag() + H2 * pIn[2].imag()
-                + H4 * pIn[4].imag() + H5 * pIn[5].imag() + H6 * pIn[6].imag()
-                + H8 * pIn[8].imag() + H10 * pIn[10].imag());
-		pIn += 2;
+	  *pOut++ = (H0 * pIn[0]) + (H2 * pIn[2]) + (H4 * pIn[4]) +
+	    (H5 * pIn[5]) + (H6 * pIn[6]) + (H8 * pIn[8]) + (H10 * pIn[10]);
+	  pIn += 2;
 	}
 
     // copy first outputs back into output array so outbuf can be same as inbuf

--- a/src/dsp/rx_meter.cpp
+++ b/src/dsp/rx_meter.cpp
@@ -65,7 +65,7 @@ int rx_meter_c::work (int noutput_items,
     if (d_num == 0)
     {
         // first sample after a reset
-        d_level = in[0].real()*in[0].real() + in[0].imag()*in[0].imag();
+        d_level = std::norm(in[0]);
         d_sum = d_level;
         d_sumsq = d_level*d_level;
         i = 1;
@@ -78,14 +78,14 @@ int rx_meter_c::work (int noutput_items,
     {
     case DETECTOR_TYPE_SAMPLE:
         // just take the first sample
-        d_level = in[0].real()*in[0].real() + in[0].imag()*in[0].imag();
+        d_level = std::norm(in[0]);
         break;
 
     case DETECTOR_TYPE_MIN:
         // minimum peak
         while (i < noutput_items)
         {
-            pwr = in[i].real()*in[i].real() + in[i].imag()*in[i].imag();
+	    pwr = std::norm(in[i]);
             if (pwr < d_level)
                 d_level = pwr;
             i++;
@@ -96,7 +96,7 @@ int rx_meter_c::work (int noutput_items,
         // maximum peak
         while (i < noutput_items)
         {
-            pwr = in[i].real()*in[i].real() + in[i].imag()*in[i].imag();
+            pwr = std::norm(in[i]);
             if (pwr > d_level)
                 d_level = pwr;
             i++;
@@ -107,7 +107,7 @@ int rx_meter_c::work (int noutput_items,
         // mean value
         while (i < noutput_items)
         {
-            pwr = in[i].real()*in[i].real() + in[i].imag()*in[i].imag();
+            pwr = std::norm(in[i]);
             d_sum += pwr;
             i++;
         }
@@ -118,7 +118,7 @@ int rx_meter_c::work (int noutput_items,
         // root mean square
         while (i < noutput_items)
         {
-            pwr = in[i].real()*in[i].real() + in[i].imag()*in[i].imag();
+            pwr = std::norm(in[i]);
             d_sumsq += pwr*pwr;
             i++;
         }


### PR DESCRIPTION
Fix use of std::complex variables, for both cleaner code as well as backwards compatibility to c++98.

I came upon this issue because the MacPorts buildbot for 10.8, which uses g++ 4.2, failed to build Gqrx because of the usage of std::complex variables. I hope I did the math correctly!