### PR TITLE
Added libgnuradio-pmt library dependency to build files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ endfunction(add_source_files)
 # 3rd Party Dependency Stuff
 find_package(Qt5 COMPONENTS Core Network Widgets REQUIRED)
 find_package(Boost COMPONENTS system program_options REQUIRED)
-set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT)
+set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT PMT)
 find_package(Gnuradio REQUIRED)
 find_package(Gnuradio-osmosdr REQUIRED)
 

--- a/gqrx.pro
+++ b/gqrx.pro
@@ -233,6 +233,7 @@ PKGCONFIG += gnuradio-analog \
              gnuradio-digital \
              gnuradio-filter \
              gnuradio-fft \
+             gnuradio-pmt \
              gnuradio-osmosdr
 
 INCPATH += src/


### PR DESCRIPTION
Without libgnuradio-pmt, linking fails in dsp/rds/decoder_impl.cc due
to an undefined reference to pmt_make_blob().

Without libgnuradio-pmt, linking fails in dsp/rds/decoder_impl.cc due
to an undefined reference to pmt_make_blob().

I experienced this linking failure with:
- gqrx @ bbed2c95dcb7a222eebe495611a753a9ed5ff5de
- gnuradio @ d55fde354f257a1dd615a66c4ca98e3b6c6a5854