### PR TITLE
Corrected pkgconfig file for libgnuradio-pmt

### DIFF
--- a/gqrx.pro
+++ b/gqrx.pro
@@ -233,7 +233,7 @@ PKGCONFIG += gnuradio-analog \
              gnuradio-digital \
              gnuradio-filter \
              gnuradio-fft \
-             gnuradio-pmt \
+             gnuradio-runtime \
              gnuradio-osmosdr
 
 INCPATH += src/


### PR DESCRIPTION
The pkgconfig entry added to gqrx.pro in 5d0b3575 is incorrect.
gnuradio-runtime.pc provides -lgnuradio-pmt.

h/t to drmpeg for quickly pointing out this issue.