### PR TITLE
Read and write squelch via remote control

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -7,7 +7,9 @@ Supported command:
  F - Set frequency [Hz]
  m - Get demodulator mode
  M - Set demodulator mode (OFF, RAW, AM, FM, WFM, WFM_ST, WFM_ST_OIRT, LSB, USB, CW, CWL, CWU)
- l - Get signal strength [dBFS]
+ l STRENGTH - Get signal strength [dBFS]
+ l SQL   - Get squelch threshold [dBFS]
+ L SQL <sql> - Set squelch threshold to <sql> [dBFS]
  c - Close connection
  AOS - Acquisition of signal (AOS) event, start audio recording
  LOS - Loss of signal (LOS) event, stop audio recording

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -252,6 +252,9 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(remote, SIGNAL(newFrequency(qint64)), ui->freqCtrl, SLOT(setFrequency(qint64)));
     connect(remote, SIGNAL(newMode(int)), this, SLOT(selectDemod(int)));
     connect(remote, SIGNAL(newMode(int)), uiDockRxOpt, SLOT(setCurrentDemod(int)));
+    connect(remote, SIGNAL(newSquelchLevel(double)), this, SLOT(setSqlLevel(double)));
+    connect(remote, SIGNAL(newSquelchLevel(double)), uiDockRxOpt, SLOT(setSquelchLevel(double)));
+    connect(uiDockRxOpt, SIGNAL(sqlLevelChanged(double)), remote, SLOT(setSquelchLevel(double)));
 
     // satellite events
     connect(remote, SIGNAL(satAosEvent()), uiDockAudio, SLOT(startAudioRecorder()));

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -231,8 +231,8 @@ void RemoteControl::startRead()
     {
         QString lvl = cmdlist.value(1, "");
         if (lvl == "?")
-            rc_socket->write("SQL METER\n");
-        else if (lvl.compare("METER", Qt::CaseInsensitive) == 0)
+            rc_socket->write("SQL STRENGTH\n");
+        else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0)
             rc_socket->write(QString("%1\n").arg(signal_level, 0, 'f', 1).toLatin1());
         else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
             rc_socket->write(QString("%1\n").arg(squelch_level, 0, 'f', 1).toLatin1());

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -207,7 +207,7 @@ void RemoteControl::startRead()
         {
             rc_socket->write("SQL\n");
         }
-        else if (lvl == "SQL")
+        else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
         {
             double squelch = cmdlist.value(2, "ERR").toDouble(&ok);
             if (ok)
@@ -232,9 +232,9 @@ void RemoteControl::startRead()
         QString lvl = cmdlist.value(1, "");
         if (lvl == "?")
             rc_socket->write("SQL METER\n");
-        else if (lvl == "METER")
+        else if (lvl.compare("METER", Qt::CaseInsensitive) == 0)
             rc_socket->write(QString("%1\n").arg(signal_level, 0, 'f', 1).toLatin1());
-        else if (lvl == "SQL")
+        else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
             rc_socket->write(QString("%1\n").arg(squelch_level, 0, 'f', 1).toLatin1());
         else
             rc_socket->write("RPRT 1\n");

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -232,7 +232,7 @@ void RemoteControl::startRead()
         QString lvl = cmdlist.value(1, "");
         if (lvl == "?")
             rc_socket->write("SQL STRENGTH\n");
-        else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0)
+        else if (lvl.compare("STRENGTH", Qt::CaseInsensitive) == 0 || lvl.isEmpty())
             rc_socket->write(QString("%1\n").arg(signal_level, 0, 'f', 1).toLatin1());
         else if (lvl.compare("SQL", Qt::CaseInsensitive) == 0)
             rc_socket->write(QString("%1\n").arg(squelch_level, 0, 'f', 1).toLatin1());

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -85,12 +85,13 @@ public slots:
     void setBandwidth(qint64 bw);
     void setSignalLevel(float level);
     void setMode(int mode);
+    void setSquelchLevel(double level);
 
 signals:
     void newFrequency(qint64 freq);
     void newFilterOffset(qint64 offset);
     void newMode(int mode);
-    void newSquelchLevel(float level);
+    void newSquelchLevel(double level);
 
     void satAosEvent(void); /*! Satellite AOS event received through the socket. */
     void satLosEvent(void); /*! Satellite LOS event received through the socket. */
@@ -112,7 +113,7 @@ private:
 
     int         rc_mode;           /*!< Current mode. */
     float       signal_level;      /*!< Signal level in dBFS */
-    float       squelch_level;     /*!< Squelch level in dBFS */
+    double      squelch_level;     /*!< Squelch level in dBFS */
 
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -90,6 +90,7 @@ signals:
     void newFrequency(qint64 freq);
     void newFilterOffset(qint64 offset);
     void newMode(int mode);
+    void newSquelchLevel(float level);
 
     void satAosEvent(void); /*! Satellite AOS event received through the socket. */
     void satLosEvent(void); /*! Satellite LOS event received through the socket. */
@@ -111,9 +112,10 @@ private:
 
     int         rc_mode;           /*!< Current mode. */
     float       signal_level;      /*!< Signal level in dBFS */
+    float       squelch_level;     /*!< Squelch level in dBFS */
 
     void        setNewRemoteFreq(qint64 freq);
-    int         modeStrToInt(const char *buffer);
+    int         modeStrToInt(QString mode_str);
     QString     intToModeStr(int mode);
 };
 

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -269,6 +269,17 @@ float DockRxOpt::currentMaxdev()
     return 5000.0;
 }
 
+
+/**
+ * @brief Set squelch level.
+ * @param level Squelch level in dBFS
+ */
+void DockRxOpt::setSquelchLevel(double level)
+{
+    ui->sqlSpinBox->setValue(level);
+}
+
+
 /** Get filter lo/hi for a given mode and preset */
 void DockRxOpt::getFilterPreset(int mode, int preset, int * lo, int * hi) const
 {

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -110,6 +110,7 @@ public:
 public slots:
     void setCurrentDemod(int demod);
     void setFilterOffset(qint64 freq_hz);
+    void setSquelchLevel(double level);
 
 private:
     void updateHwFreq();


### PR DESCRIPTION
Allows read and write of squelch level over TCP.
I also rewrote some of the remote control code to allow spaces in commands.
#282