### PR TITLE
Created compatibility file resources for /dev/null + random

### DIFF
--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -11,6 +11,7 @@ add_source_files(SRCS_LIST
 	gqrx/remote_control_settings.h
 	gqrx/remote_control.cpp
 	gqrx/remote_control.h
+	gqrx/file_resources.cpp
 )
 
 #######################################################################################################################

--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -1,0 +1,74 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright (c) 2016 Josh Blum <josh@joshknows.com>
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "applications/gqrx/receiver.h"
+#include <QFileInfo>
+#include <QTemporaryFile>
+#include <QDataStream>
+#include <iostream>
+
+std::string receiver::get_random_file(void)
+{
+    static std::string path;
+    if (path.empty())
+    {
+        path = "/dev/random";
+        QFileInfo checkFile(QString::fromStdString(path));
+        if (!checkFile.exists())
+        {
+            //static temp file persists until process end
+            static QTemporaryFile temp_file;
+            temp_file.open();
+            path = temp_file.fileName().toStdString();
+            {
+                QDataStream stream(&temp_file);
+                for (size_t i = 0; i < 1024*8; i++) stream << qint8(rand());
+            }
+            std::cout << "Created random file " << path << std::endl;
+        }
+    }
+    return path;
+}
+
+std::string receiver::get_null_file(void)
+{
+    static std::string path;
+    if (path.empty())
+    {
+        path = "/dev/null";
+        QFileInfo checkFile(QString::fromStdString(path));
+        if (!checkFile.exists())
+        {
+            //static temp file persists until process end
+            static QTemporaryFile temp_file;
+            temp_file.open();
+            path = temp_file.fileName().toStdString();
+            {
+                QDataStream stream(&temp_file);
+                for (size_t i = 0; i < 1024*8; i++) stream << qint8(0);
+            }
+            std::cout << "Created null file " << path << std::endl;
+        }
+    }
+    return path;
+}

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -77,8 +77,7 @@ receiver::receiver(const std::string input_device,
 
     if (input_device.empty())
     {
-        // FIXME: other OS
-        src = osmosdr::source::make("file=/dev/random,freq=428e6,rate=96000,repeat=true,throttle=true");
+        src = osmosdr::source::make("file="+get_random_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
     }
     else
     {
@@ -110,7 +109,7 @@ receiver::receiver(const std::string input_device,
 
 
     // create I/Q sink and close it
-    iq_sink = gr::blocks::file_sink::make(sizeof(gr_complex), "/dev/null", false);
+    iq_sink = gr::blocks::file_sink::make(sizeof(gr_complex), get_null_file().c_str(), true);
     iq_sink->set_unbuffered(true);
     iq_sink->close();
 
@@ -127,7 +126,7 @@ receiver::receiver(const std::string input_device,
     audio_gain0 = gr::blocks::multiply_const_ff::make(0.1);
     audio_gain1 = gr::blocks::multiply_const_ff::make(0.1);
 
-    wav_sink = gr::blocks::wavfile_sink::make("/dev/null", 2,
+    wav_sink = gr::blocks::wavfile_sink::make(get_null_file().c_str(), 2,
                                               (unsigned int) d_audio_rate,
                                               16);
 

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -272,6 +272,12 @@ private:
 #else
     gr::audio::sink::sptr     audio_snk;  /*!< gr audio sink */
 #endif
+
+    //! Get a path to a file containing random bytes
+    static std::string get_random_file(void);
+
+    //! Get a path to a file containing all-zero bytes
+    static std::string get_null_file(void);
 };
 
 #endif // RECEIVER_H


### PR DESCRIPTION
Random and null file are used to support GQRX receiver source
with file resouces when actual devices are not available.
This commit adds functions get_random_file() and get_null_file()
to the receiver class to get a path to a random and zero file resource respectively.
The functions will try and use /dev/random and /dev/null when available.
Otherwise the function will generate a temp file to be used as a suitable replacement.