### PR TITLE
Control audio recorder via TCP socket

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -8,6 +8,8 @@ Supported command:
  l STRENGTH - Get signal strength [dBFS]
  l SQL   - Get squelch threshold [dBFS]
  L SQL <sql> - Set squelch threshold to <sql> [dBFS]
+ u RECORD - Get status of audio recorder
+ U RECORD <status> - Set status of audio recorder to <status>
  c - Close connection
  AOS - Acquisition of signal (AOS) event, start audio recording
  LOS - Loss of signal (LOS) event, stop audio recording

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -218,7 +218,9 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(uiDockAudio, SIGNAL(audioStreamingStarted(QString,int)), this, SLOT(startAudioStream(QString,int)));
     connect(uiDockAudio, SIGNAL(audioStreamingStopped()), this, SLOT(stopAudioStreaming()));
     connect(uiDockAudio, SIGNAL(audioRecStarted(QString)), this, SLOT(startAudioRec(QString)));
+    connect(uiDockAudio, SIGNAL(audioRecStarted(QString)), remote, SLOT(startAudioRecorder(QString)));
     connect(uiDockAudio, SIGNAL(audioRecStopped()), this, SLOT(stopAudioRec()));
+    connect(uiDockAudio, SIGNAL(audioRecStopped()), remote, SLOT(stopAudioRecorder()));
     connect(uiDockAudio, SIGNAL(audioPlayStarted(QString)), this, SLOT(startAudioPlayback(QString)));
     connect(uiDockAudio, SIGNAL(audioPlayStopped()), this, SLOT(stopAudioPlayback()));
     connect(uiDockAudio, SIGNAL(fftRateChanged(int)), this, SLOT(setAudioFftRate(int)));
@@ -264,10 +266,8 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(remote, SIGNAL(newSquelchLevel(double)), this, SLOT(setSqlLevel(double)));
     connect(remote, SIGNAL(newSquelchLevel(double)), uiDockRxOpt, SLOT(setSquelchLevel(double)));
     connect(uiDockRxOpt, SIGNAL(sqlLevelChanged(double)), remote, SLOT(setSquelchLevel(double)));
-
-    // satellite events
-    connect(remote, SIGNAL(satAosEvent()), uiDockAudio, SLOT(startAudioRecorder()));
-    connect(remote, SIGNAL(satLosEvent()), uiDockAudio, SLOT(stopAudioRecorder()));
+    connect(remote, SIGNAL(startAudioRecorderEvent()), uiDockAudio, SLOT(startAudioRecorder()));
+    connect(remote, SIGNAL(stopAudioRecorderEvent()), uiDockAudio, SLOT(stopAudioRecorder()));
 
     rds_timer = new QTimer(this);
     connect(rds_timer, SIGNAL(timeout()), this, SLOT(rdsTimeout()));

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1654,6 +1654,8 @@ void MainWindow::forceRxReconf()
  */
 void MainWindow::on_actionDSP_triggered(bool checked)
 {
+    remote->setReceiverStatus(checked);
+
     if (checked)
     {
         /* start receiver */

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -316,13 +316,18 @@ void RemoteControl::startRead()
     //   LOS  - satellite LOS event
     else if (cmdlist[0] == "AOS")
     {
-        emit startAudioRecorderEvent();
+        if (rc_mode >= 2)
+        {
+            emit startAudioRecorderEvent();
+            audio_recorder_status = true;
+        }
         rc_socket->write("RPRT 0\n");
 
     }
     else if (cmdlist[0] == "LOS")
     {
         emit stopAudioRecorderEvent();
+        audio_recorder_status = false;
         rc_socket->write("RPRT 0\n");
 
     }
@@ -435,7 +440,8 @@ void RemoteControl::setSquelchLevel(double level)
 /*! \brief Start audio recorder (from mainwindow). */
 void RemoteControl::startAudioRecorder(QString unused)
 {
-    audio_recorder_status = true;
+    if (rc_mode >= 2)
+        audio_recorder_status = true;
 }
 
 /*! \brief Stop audio recorder (from mainwindow). */

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -252,6 +252,10 @@ void RemoteControl::startRead()
         {
             rc_socket->write("RPRT 0\n");
             rc_mode = mode;
+
+            if (rc_mode < 2)
+                audio_recorder_status = false;
+
             emit newMode(rc_mode);
         }
     }
@@ -396,6 +400,9 @@ void RemoteControl::setSignalLevel(float level)
 void RemoteControl::setMode(int mode)
 {
     rc_mode = mode;
+
+    if (rc_mode < 2)
+        audio_recorder_status = false;
 }
 
 /*! \brief New remote frequency received. */

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -38,6 +38,7 @@ RemoteControl::RemoteControl(QObject *parent) :
     signal_level = -200.0;
     squelch_level = -150.0;
     audio_recorder_status = false;
+    receiver_running = false;
 
     rc_port = 7356;
     rc_allowed_hosts.append("::ffff:127.0.0.1");
@@ -279,7 +280,7 @@ void RemoteControl::startRead()
         }
         else if (func.compare("RECORD", Qt::CaseInsensitive) == 0)
         {
-            if (rc_mode < 2)
+            if (rc_mode < 2 || !receiver_running)
             {
                 rc_socket->write("RPRT 1\n");
             }
@@ -316,7 +317,7 @@ void RemoteControl::startRead()
     //   LOS  - satellite LOS event
     else if (cmdlist[0] == "AOS")
     {
-        if (rc_mode >= 2)
+        if (rc_mode >= 2 && receiver_running)
         {
             emit startAudioRecorderEvent();
             audio_recorder_status = true;
@@ -449,6 +450,13 @@ void RemoteControl::stopAudioRecorder()
 {
     audio_recorder_status = false;
 }
+
+/*! \brief Set receiver status (from mainwindow). */
+void RemoteControl::setReceiverStatus(bool enabled)
+{
+    receiver_running = enabled;
+}
+
 
 /*! \brief Convert mode string to enum (DockRxOpt::rxopt_mode_idx)
  *  \param mode The Hamlib rigctld compatible mode string

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -86,15 +86,16 @@ public slots:
     void setSignalLevel(float level);
     void setMode(int mode);
     void setSquelchLevel(double level);
+    void startAudioRecorder(QString unused);
+    void stopAudioRecorder();
 
 signals:
     void newFrequency(qint64 freq);
     void newFilterOffset(qint64 offset);
     void newMode(int mode);
     void newSquelchLevel(double level);
-
-    void satAosEvent(void); /*! Satellite AOS event received through the socket. */
-    void satLosEvent(void); /*! Satellite LOS event received through the socket. */
+    void startAudioRecorderEvent();
+    void stopAudioRecorderEvent();
 
 private slots:
     void acceptConnection();
@@ -114,6 +115,7 @@ private:
     int         rc_mode;           /*!< Current mode. */
     float       signal_level;      /*!< Signal level in dBFS */
     double      squelch_level;     /*!< Squelch level in dBFS */
+    bool        audio_recorder_status; /*!< Recording enabled */
 
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -78,6 +78,7 @@ public:
     {
         return rc_allowed_hosts;
     }
+    void setReceiverStatus(bool enabled);
 
 public slots:
     void setNewFrequency(qint64 freq);
@@ -116,6 +117,7 @@ private:
     float       signal_level;      /*!< Signal level in dBFS */
     double      squelch_level;     /*!< Squelch level in dBFS */
     bool        audio_recorder_status; /*!< Recording enabled */
+    bool        receiver_running;  /*!< Wether the receiver is running or not */
 
     void        setNewRemoteFreq(qint64 freq);
     int         modeStrToInt(QString mode_str);


### PR DESCRIPTION
Adds support to control the audio recorder via remote control.
The commands are compatible to rigctl, using the 'u' and 'U' (get and set_func) commands.

Enable recording with "U RECORD 1" and disable with "U RECORD 0".
The status of the recorder is returned by "u RECORD".