### PR TITLE
Prevent IQ panel from crashing on random *.raw

### DIFF
--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -437,6 +437,9 @@ qint64 CIqTool::sampleRateFromFileName(const QString &filename)
 
     QStringList list = filename.split('_');
 
+    if (list.size() < 5)
+        return sample_rate;
+
     // gqrx_yymmdd_hhmmss_freq_samprate_fc.raw
     sr = list.at(4).toLongLong(&ok);
 


### PR DESCRIPTION
If a random *.raw filename in the user's home directory doesn't contain the expected `gqrx_yymmdd_hhmmss_freq_samprate_fc.raw` pattern, and the user clicks on it, `sampleRateFromFileName` would crash.
