### PR TITLE
[alsa-devices] Let ALSA users pick a sound card

### DIFF
--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -153,6 +153,8 @@ CIoConfig::CIoConfig(QSettings *settings, std::map<QString, QVariant> &devList, 
     }
 
 #else
+    ui->outDevCombo->addItem(settings->value("output/device", "Default").toString(),
+                             settings->value("output/device", "Default").toString());
     ui->outDevCombo->setEditable(true);
 #endif // WITH_PULSEAUDIO
 
@@ -254,12 +256,20 @@ void CIoConfig::saveConfig()
 
     idx = ui->outDevCombo->currentIndex();
 
-    if (idx > 0)
+    if (idx > 0
+        #if !defined(WITH_PULSEAUDIO) && !defined(GQRX_OS_MACX)
+            || ui->outDevCombo->currentText() != "Default"
+        #endif
+            )
     {
 #if defined(WITH_PULSEAUDIO) || defined(GQRX_OS_MACX)
         qDebug() << "Output device" << idx << ":" << QString(outDevList[idx-1].get_name().c_str());
         m_settings->setValue("output/device", QString(outDevList[idx-1].get_name().c_str()));
+#else
+        qDebug() << "Output device:" << ui->outDevCombo->currentText();
+        m_settings->setValue("output/device", ui->outDevCombo->currentText());
 #endif
+
     }
     else
     {

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -256,21 +256,19 @@ void CIoConfig::saveConfig()
 
     idx = ui->outDevCombo->currentIndex();
 
-    if (idx > 0
-        #if !defined(WITH_PULSEAUDIO) && !defined(GQRX_OS_MACX)
-            || ui->outDevCombo->currentText() != "Default"
-        #endif
-            )
-    {
 #if defined(WITH_PULSEAUDIO) || defined(GQRX_OS_MACX)
-        qDebug() << "Output device" << idx << ":" << QString(outDevList[idx-1].get_name().c_str());
-        m_settings->setValue("output/device", QString(outDevList[idx-1].get_name().c_str()));
+    if (idx > 0)
+    {
+          qDebug() << "Output device" << idx << ":" << QString(outDevList[idx-1].get_name().c_str());
+          m_settings->setValue("output/device", QString(outDevList[idx-1].get_name().c_str()));
+    }
 #else
+    if (idx > 0 || ui->outDevCombo->currentText() != "Default")
+    {
         qDebug() << "Output device:" << ui->outDevCombo->currentText();
         m_settings->setValue("output/device", ui->outDevCombo->currentText());
-#endif
-
     }
+#endif
     else
     {
         m_settings->remove("output/device");


### PR DESCRIPTION
Currently ALSA users can't pick an output sound card. With this patch, it's possible to enter (and save) usual ALSA strings like "hw:0,0" to do so.