### PR TITLE
Draw small negative frequencies correctly

### DIFF
--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -707,8 +707,12 @@ void CFreqCtrl::drawDigits(QPainter &Painter)
             else
                 Painter.setPen(m_DigitColor);
 
-            Painter.drawText(m_DigitInfo[i].dQRect, Qt::AlignHCenter|Qt::AlignVCenter,
-                             QString().number(m_DigitInfo[i].val));
+            if (m_freq < 0 && i == m_LeadZeroPos - 1 && m_DigitInfo[i].val == 0)
+                Painter.drawText(m_DigitInfo[i].dQRect, Qt::AlignHCenter|Qt::AlignVCenter,
+                                 QString("-%1").arg(m_DigitInfo[i].val));
+            else
+                Painter.drawText(m_DigitInfo[i].dQRect, Qt::AlignHCenter|Qt::AlignVCenter,
+                                 QString().number(m_DigitInfo[i].val));
             m_DigitInfo[i].modified = false;
         }
     }

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -261,6 +261,12 @@ void CFreqCtrl::setFrequency(qint64 freq)
             m_LeadZeroPos = i;
         }
     }
+
+    // If the sign changed and the frequency is less than 1 unit,
+    // redraw the leading zero to get the correct sign.
+    if(m_Oldfreq ^ m_freq < 0 && m_DigitInfo[m_LeadZeroPos-1].val == 0)
+      m_DigitInfo[m_LeadZeroPos-1].modified = true;
+
     // When frequency is negative all non-zero digits that
     // have changed will have a negative sign. This loop will
     // change all digits back to positive, except the one at

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -264,7 +264,8 @@ void CFreqCtrl::setFrequency(qint64 freq)
     // When frequency is negative all non-zero digits that
     // have changed will have a negative sign. This loop will
     // change all digits back to positive, except the one at
-    // position m_leadZeroPos-1
+    // position m_leadZeroPos-1. If that position is zero,
+    // it will be checked in the drawing method, drawDigits().
     /** TBC if this works for all configurations */
     if (m_freq < 0)
     {

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -710,7 +710,7 @@ void CFreqCtrl::drawDigits(QPainter &Painter)
 
             if (m_freq < 0 && i == m_LeadZeroPos - 1 && m_DigitInfo[i].val == 0)
                 Painter.drawText(m_DigitInfo[i].dQRect, Qt::AlignHCenter|Qt::AlignVCenter,
-                                 QString("-%1").arg(m_DigitInfo[i].val));
+                                 QString("-0"));
             else
                 Painter.drawText(m_DigitInfo[i].dQRect, Qt::AlignHCenter|Qt::AlignVCenter,
                                  QString().number(m_DigitInfo[i].val));


### PR DESCRIPTION
This would be a fix for #388. Having to check this in the drawing method's a bit ugly, but I think we'd have to change the digitinfo struct to use a separate sign and value otherwise.