### PR TITLE
When resetting FFT Zoom, reset slider too

### DIFF
--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -383,6 +383,8 @@ void DockFft::on_rangeSlider_valueChanged(int value)
 
 void DockFft::on_resetButton_clicked(void)
 {
+    ui->zoomLevelLabel->setText(QString("1x"));
+    ui->fftZoomSlider->setValue(0);
     emit resetFftZoom();
 }
 


### PR DESCRIPTION
Make sure that when the FFT zoom is reset using the reset button, that the slider UI element (and associated label) are also reset simultaneously.

This is a pretty trivial change, but it's a UI bug that has been making me crazy.