### PR TITLE
Update squelch level when demodulator has changed

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1057,6 +1057,7 @@ void MainWindow::selectDemod(int mode_idx)
     ui->plotter->setFilterClickResolution(click_res);
     rx->set_filter((double)flo, (double)fhi, d_filter_shape);
     rx->set_cw_offset(cwofs);
+    rx->set_sql_level(uiDockRxOpt->currentSquelchLevel());
 
     d_have_audio = ((mode_idx != DockRxOpt::MODE_OFF) &&
                     (mode_idx != DockRxOpt::MODE_RAW));

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -283,6 +283,15 @@ void DockRxOpt::setSquelchLevel(double level)
     ui->sqlSpinBox->setValue(level);
 }
 
+/**
+ * @brief Get the current squelch level
+ * @returns The current squelch setting in dBFS
+ */
+double DockRxOpt::currentSquelchLevel()
+{
+    return ui->sqlSpinBox->value();
+}
+
 
 /** Get filter lo/hi for a given mode and preset */
 void DockRxOpt::getFilterPreset(int mode, int preset, int * lo, int * hi) const

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -100,6 +100,8 @@ public:
 
     float currentMaxdev();
 
+    double currentSquelchLevel();
+
     void    getFilterPreset(int mode, int preset, int * lo, int * hi) const;
     int     getCwOffset() const;
 


### PR DESCRIPTION
When the receiver switched between WBRX and NBRX, the squelch level was not updated.
Fixes #397