### PR TITLE
Set correct filter range when loading bookmark

### DIFF
--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -192,6 +192,9 @@ private slots:
     /* RDS */
     void setRdsDecoder(bool checked);
 
+    /* Bookmarks */
+    void onBookmarkActivated(qint64 freq, QString demod, int bandwidth);
+
     /* menu and toolbar actions */
     void on_actionDSP_triggered(bool checked);
     int  on_actionIoConfig_triggered();

--- a/src/qtgui/dockbookmarks.cpp
+++ b/src/qtgui/dockbookmarks.cpp
@@ -104,11 +104,7 @@ DockBookmarks::~DockBookmarks()
 void DockBookmarks::activated(const QModelIndex & index )
 {
     BookmarkInfo *info = bookmarksTableModel->getBookmarkAtRow(index.row());
-    //printf("Emit newFrequency(%d)\n", (int)info->frequency);
-    emit newFrequency(info->frequency);
-    //printf("Emit newDemodulation(%s)\n", info->modulation.toStdString().c_str());
-    emit newDemodulation(info->modulation);
-    emit newFilterBandwidth(-1*info->bandwidth/2, info->bandwidth/2);
+    emit newBookmarkActivated(info->frequency, info->modulation, info->bandwidth);
 }
 
 void DockBookmarks::setNewFrequency(qint64 rx_freq)

--- a/src/qtgui/dockbookmarks.h
+++ b/src/qtgui/dockbookmarks.h
@@ -80,9 +80,7 @@ public:
     void changeBookmarkTags(int row, int /*column*/);
 
 signals:
-    void newFrequency(qint64);
-    void newDemodulation(QString);
-    void newFilterBandwidth(int, int);
+    void newBookmarkActivated(qint64, QString, int);
 
 public slots:
     void setNewFrequency(qint64 rx_freq);


### PR DESCRIPTION
* Display the correct filter width on spectrum.
* Calculate the correct taps for RX filter. Previously, the RX filter was configured symmetric with bandwidth/2 around the center frequency, regardless of the selected demodulator.

Fixes #349