### PR TITLE
Revert "Bookmarks: sort tags too."

### DIFF
--- a/src/qtgui/bookmarks.cpp
+++ b/src/qtgui/bookmarks.cpp
@@ -137,7 +137,6 @@ bool Bookmarks::load()
             }
         }
         file.close();
-        std::sort(m_TagList.begin(),m_TagList.end());
         std::stable_sort(m_BookmarkList.begin(),m_BookmarkList.end());
 
         emit BookmarksChanged();
@@ -247,7 +246,6 @@ TagInfo &Bookmarks::findOrAddTag(QString tagName)
     TagInfo info;
     info.name=tagName;
     m_TagList.append(info);
-    std::sort(m_TagList.begin(),m_TagList.end());
     emit TagListChanged();
     return m_TagList.last();
 }

--- a/src/qtgui/bookmarks.h
+++ b/src/qtgui/bookmarks.h
@@ -51,10 +51,6 @@ struct TagInfo
         this->color=DefaultColor;
         this->name = name;
     }
-    bool operator<(const TagInfo &other) const
-    {
-        return name < other.name;
-    }
 };
 
 struct BookmarkInfo


### PR DESCRIPTION
Reverts csete/gqrx#418

Sorry I found the ugly bug when added bookmarks. Please revert it.