### PR TITLE
Bookmarks: sort tags only in load before bookmarks.

### DIFF
--- a/src/qtgui/bookmarks.cpp
+++ b/src/qtgui/bookmarks.cpp
@@ -105,6 +105,7 @@ bool Bookmarks::load()
                 printf("\nBookmarks: Ignoring Line:\n  %s\n", line.toLatin1().data());
             }
         }
+        std::sort(m_TagList.begin(),m_TagList.end());
 
         // Read Bookmarks, after first empty line.
         while (!file.atEnd())
@@ -137,7 +138,6 @@ bool Bookmarks::load()
             }
         }
         file.close();
-        std::sort(m_TagList.begin(),m_TagList.end());
         std::stable_sort(m_BookmarkList.begin(),m_BookmarkList.end());
 
         emit BookmarksChanged();
@@ -247,7 +247,6 @@ TagInfo &Bookmarks::findOrAddTag(QString tagName)
     TagInfo info;
     info.name=tagName;
     m_TagList.append(info);
-    std::sort(m_TagList.begin(),m_TagList.end());
     emit TagListChanged();
     return m_TagList.last();
 }


### PR DESCRIPTION
The code uses tag index for coupling between bookmark and tag.
Reorder tags breaks it.

Correct fix for #418 and #420.