### PR TITLE
Keep zoom-slider and waterfall zoom synchronized

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -235,6 +235,8 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
             ui->plotter, SLOT(setWaterfallRange(float,float)));
     connect(ui->plotter, SIGNAL(pandapterRangeChanged(float,float)),
             uiDockFft, SLOT(setPandapterRange(float,float)));
+    connect(ui->plotter, SIGNAL(newZoomLevel(float)),
+            uiDockFft, SLOT(setZoomLevel(float)));
 
     connect(uiDockFft, SIGNAL(fftColorChanged(QColor)), this, SLOT(setFftColor(QColor)));
     connect(uiDockFft, SIGNAL(fftFillToggled(bool)), this, SLOT(setFftFill(bool)));

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -334,6 +334,14 @@ void DockFft::setWaterfallRange(float min, float max)
     ui->wfRangeSlider->blockSignals(false);
 }
 
+void DockFft::setZoomLevel(float level)
+{
+    ui->fftZoomSlider->blockSignals(true);
+    ui->fftZoomSlider->setValue((int) level);
+    ui->zoomLevelLabel->setText(QString("%1x").arg((int) level));
+    ui->fftZoomSlider->blockSignals(false);
+}
+
 /** FFT size changed. */
 void DockFft::on_fftSizeComboBox_currentIndexChanged(const QString &text)
 {

--- a/src/qtgui/dockfft.h
+++ b/src/qtgui/dockfft.h
@@ -71,6 +71,7 @@ public slots:
     void setPandapterRange(float min, float max);
     void setWaterfallRange(float min, float max);
     void setWfResolution(quint64 msec_per_line);
+    void setZoomLevel(float level);
 
 private slots:
     void on_fftSizeComboBox_currentIndexChanged(const QString & text);

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -771,6 +771,7 @@ void CPlotter::zoomStepX(float step, int x)
     setSpanFreq((quint32)new_range);
 
     float factor = (float)m_SampleFreq / (float)m_Span;
+    emit newZoomLevel(factor);
     qDebug() << QString("Spectrum zoom: %1x").arg(factor, 0, 'f', 1);
 
     m_PeakHoldValid = false;

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -121,6 +121,7 @@ signals:
     void newHighCutFreq(int f);
     void newFilterFreq(int low, int high);  /* substitute for NewLow / NewHigh */
     void pandapterRangeChanged(float min, float max);
+    void newZoomLevel(float level);
 
 public slots:
     // zoom functions


### PR DESCRIPTION
Not perfect, because the plotter widget allows zooming well beyond the range of the slider, but they are kept synchronized within reasonable ranges.