### PR TITLE
The 'm' command must returns a passband on new line.

### DIFF
--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -284,7 +284,7 @@ void RemoteControl::startRead()
     }
     else if (cmdlist[0] == "m")
     {
-        QString msg = QString("%1 %2\n")
+        QString msg = QString("%1\n%2\n")
                               .arg(intToModeStr(rc_mode))
                               .arg(rc_passband_hi - rc_passband_lo);
         rc_socket->write(msg.toLatin1());


### PR DESCRIPTION
Sorry. That's my fault.

```
Rig command: m
netrigctl_get_mode called
write_block(): TX 2 bytes
0000    6d 0a                                               m.              
read_string(): RX 3 characters
0000    46 4d 0a                                            FM.             
read_string(): RX 6 characters
0000    31 30 30 30 30 0a                                   10000.          
Mode: FM
Passband: 10000

Rig command: 
```