### PR TITLE
Add checkbox to select frequency control widget reset behavior

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -192,6 +192,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(uiDockInputCtl, SIGNAL(iqBalanceChanged(bool)), this, SLOT(setIqBalance(bool)));
     connect(uiDockInputCtl, SIGNAL(ignoreLimitsChanged(bool)), this, SLOT(setIgnoreLimits(bool)));
     connect(uiDockInputCtl, SIGNAL(antennaSelected(QString)), this, SLOT(setAntenna(QString)));
+    connect(uiDockInputCtl, SIGNAL(freqCtrlResetChanged(bool)), this, SLOT(setFreqCtrlReset(bool)));
     connect(uiDockRxOpt, SIGNAL(filterOffsetChanged(qint64)), this, SLOT(setFilterOffset(qint64)));
     connect(uiDockRxOpt, SIGNAL(filterOffsetChanged(qint64)), remote, SLOT(setFilterOffset(qint64)));
     connect(uiDockRxOpt, SIGNAL(demodSelected(int)), this, SLOT(selectDemod(int)));
@@ -452,10 +453,6 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
                                           saveGeometry()).toByteArray());
         restoreState(m_settings->value("gui/state", saveState()).toByteArray());
     }
-
-    // misc GUI settings
-    bool_val = m_settings->value("gui/fctl_reset_digits", true).toBool();
-    ui->freqCtrl->setResetLowerDigits(bool_val);
 
     QString indev = m_settings->value("input/device", "").toString();
     if (!indev.isEmpty())
@@ -930,6 +927,13 @@ void MainWindow::setIgnoreLimits(bool ignore_limits)
     // the UI is updated with the correct frequency.
     freq = ui->freqCtrl->getFrequency();
     setNewFrequency(freq);
+}
+
+
+/** Reset lower digits of main frequency control widget */
+void MainWindow::setFreqCtrlReset(bool enabled)
+{
+    ui->freqCtrl->setResetLowerDigits(enabled);
 }
 
 /**

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -139,6 +139,7 @@ private slots:
     void setDcCancel(bool enabled);
     void setIqBalance(bool enabled);
     void setIgnoreLimits(bool ignore_limits);
+    void setFreqCtrlReset(bool enabled);
     void selectDemod(QString demod);
     void selectDemod(int index);
     void setFmMaxdev(float max_dev);

--- a/src/qtgui/dockinputctl.cpp
+++ b/src/qtgui/dockinputctl.cpp
@@ -104,6 +104,11 @@ void DockInputCtl::readSettings(QSettings * settings)
             emit gainChanged(gain_name, gain_value);
         }
     }
+
+    // misc GUI settings
+    bool_val = settings->value("gui/fctl_reset_digits", true).toBool();
+    emit freqCtrlResetChanged(bool_val);
+    ui->freqCtrlResetButton->setChecked(bool_val);
 }
 
 void DockInputCtl::saveSettings(QSettings * settings)
@@ -159,6 +164,12 @@ void DockInputCtl::saveSettings(QSettings * settings)
         settings->setValue("input/antenna", ui->antSelector->currentText());
     else
         settings->remove("input/antenna");
+
+    // Remember state of freqReset button. Default is checked.
+    if (!ui->freqCtrlResetButton->isChecked())
+        settings->setValue("gui/fctl_reset_digits", false);
+    else
+        settings->remove("gui/fctl_reset_digits");
 }
 
 void DockInputCtl::readLnbLoFromSettings(QSettings * settings)
@@ -325,6 +336,12 @@ void DockInputCtl::setAntenna(const QString &antenna)
         ui->antSelector->setCurrentIndex(index);
 }
 
+/** Enable/disable resetting lower digits on freqCtrl widgets */
+void DockInputCtl::setFreqCtrlReset(bool enabled)
+{
+    ui->freqCtrlResetButton->setChecked(enabled);
+}
+
 /**
  * Set gain stages.
  * @param gain_list A list containing the gain stages for this device.
@@ -482,6 +499,12 @@ void DockInputCtl::on_ignoreButton_toggled(bool checked)
 void DockInputCtl::on_antSelector_currentIndexChanged(const QString &antenna)
 {
     emit antennaSelected(antenna);
+}
+
+/** Reset box has changed */
+void DockInputCtl::on_freqCtrlResetButton_toggled(bool checked)
+{
+    emit freqCtrlResetChanged(checked);
 }
 
 /** Remove all widgets from the lists. */

--- a/src/qtgui/dockinputctl.h
+++ b/src/qtgui/dockinputctl.h
@@ -101,6 +101,8 @@ public:
     void    setGainStages(gain_list_t &gain_list);
     void    restoreManualGains(QSettings *settings);
 
+    void    setFreqCtrlReset(bool enabled);
+
 signals:
     void gainChanged(QString name, double value);
     void autoGainChanged(bool enabled);
@@ -111,6 +113,7 @@ signals:
     void iqBalanceChanged(bool enabled);
     void ignoreLimitsChanged(bool ignore);
     void antennaSelected(QString antenna);
+    void freqCtrlResetChanged(bool enabled);
 
 private slots:
     void on_lnbSpinBox_valueChanged(double value);
@@ -121,6 +124,7 @@ private slots:
     void on_iqBalanceButton_toggled(bool checked);
     void on_ignoreButton_toggled(bool checked);
     void on_antSelector_currentIndexChanged(const QString &antenna);
+    void on_freqCtrlResetButton_toggled(bool checked);
 
     void sliderValueChanged(int value);
 

--- a/src/qtgui/dockinputctl.ui
+++ b/src/qtgui/dockinputctl.ui
@@ -215,6 +215,16 @@
      </layout>
     </item>
     <item>
+     <widget class="QCheckBox" name="freqCtrlResetButton">
+      <property name="toolTip">
+       <string>Reset lower digits of main frequency control widget</string>
+      </property>
+      <property name="text">
+       <string>Reset frequency control</string>
+      </property>
+     </widget>
+    </item>
+    <item>
      <spacer name="verticalSpacer">
       <property name="orientation">
        <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Issue #445.

Adds a checkbox to select the behavior of the frequency control widget from the GUI.

I didn't really know how to name the button and where to put it. It's currently in the input-control dock and called "Reset frequency control".