### PR TITLE
Check if new and old configuration file are equal

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -635,6 +635,11 @@ bool MainWindow::saveConfig(const QString cfgfile)
     else
         newfile = QString("%1/%2").arg(m_cfg_dir).arg(cfgfile);
 
+    if (newfile == oldfile) {
+        qDebug() << "New file is equal to old file => SYNCING...";
+        return true;
+    }
+
     if (QFile::exists(newfile))
     {
         qDebug() << "File" << newfile << "already exists => DELETING...";


### PR DESCRIPTION
Fixes #493 
Keeps the old behavior of syncing before "save as", but checks if old and new configuration files are equal.