### PR TITLE
IQ rec/play: Fix navigation in large IQ files

### DIFF
--- a/src/qtgui/iq_tool.cpp
+++ b/src/qtgui/iq_tool.cpp
@@ -230,7 +230,7 @@ void CIqTool::on_slider_valueChanged(int value)
 {
     refreshTimeWidgets();
 
-    qint64 seek_pos = (qint64)(value*sample_rate);
+    qint64 seek_pos = (qint64)(value)*sample_rate;
     emit seek(seek_pos);
 }
 


### PR DESCRIPTION
Fixed a play navigation error in large IQ files due to integer overflow.

Signed-off-by: Wolfgang Fritz <removed email address>

PR for #538 