### PR TITLE
Add LNB_LO command to remote control interface

### DIFF
--- a/resources/remote-control.txt
+++ b/resources/remote-control.txt
@@ -27,6 +27,9 @@ Supported commands:
     Acquisition of signal (AOS) event, start audio recording
  LOS
     Loss of signal (LOS) event, stop audio recording
+ LNB_LO [frequency]
+    If frequency [Hz] is specified set the LNB LO frequency used for
+    display. Otherwise print the current LNB LO frequency [Hz].
  \dump_state
     Dump state (only usable for hamlib compatibility)
  v

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -186,6 +186,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(ui->freqCtrl, SIGNAL(newFrequency(qint64)), uiDockAudio, SLOT(setRxFrequency(qint64)));
     connect(ui->freqCtrl, SIGNAL(newFrequency(qint64)), uiDockRxOpt, SLOT(setRxFreq(qint64)));
     connect(uiDockInputCtl, SIGNAL(lnbLoChanged(double)), this, SLOT(setLnbLo(double)));
+    connect(uiDockInputCtl, SIGNAL(lnbLoChanged(double)), remote, SLOT(setLnbLo(double)));
     connect(uiDockInputCtl, SIGNAL(gainChanged(QString, double)), this, SLOT(setGain(QString,double)));
     connect(uiDockInputCtl, SIGNAL(autoGainChanged(bool)), this, SLOT(setAutoGain(bool)));
     connect(uiDockInputCtl, SIGNAL(freqCorrChanged(double)), this, SLOT(setFreqCorr(double)));
@@ -264,6 +265,8 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(remote, SIGNAL(newFilterOffset(qint64)), this, SLOT(setFilterOffset(qint64)));
     connect(remote, SIGNAL(newFilterOffset(qint64)), uiDockRxOpt, SLOT(setFilterOffset(qint64)));
     connect(remote, SIGNAL(newFrequency(qint64)), ui->freqCtrl, SLOT(setFrequency(qint64)));
+    connect(remote, SIGNAL(newLnbLo(double)), uiDockInputCtl, SLOT(setLnbLo(double)));
+    connect(remote, SIGNAL(newLnbLo(double)), this, SLOT(setLnbLo(double)));
     connect(remote, SIGNAL(newMode(int)), this, SLOT(selectDemod(int)));
     connect(remote, SIGNAL(newMode(int)), uiDockRxOpt, SLOT(setCurrentDemod(int)));
     connect(remote, SIGNAL(newSquelchLevel(double)), this, SLOT(setSqlLevel(double)));

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -226,6 +226,8 @@ void RemoteControl::startRead()
         answer = cmd_AOS();
     else if (cmd == "LOS")
         answer = cmd_LOS();
+    else if (cmd == "LNB_LO")
+        answer = cmd_lnb_lo(cmdlist);
     else if (cmd == "\\dump_state")
         answer = cmd_dump_state();
     else if (cmd == "q" || cmd == "Q")
@@ -259,6 +261,14 @@ void RemoteControl::setNewFrequency(qint64 freq)
 void RemoteControl::setFilterOffset(qint64 freq)
 {
     rc_filter_offset = freq;
+}
+
+/*! \brief Slot called when the LNB LO frequency has changed
+ *  \param freq_mhz new LNB LO frequency in MHz
+ */
+void RemoteControl::setLnbLo(double freq_mhz)
+{
+    rc_lnb_lo_mhz = freq_mhz;
 }
 
 void RemoteControl::setBandwidth(qint64 bw)
@@ -697,6 +707,29 @@ QString RemoteControl::cmd_LOS()
     emit stopAudioRecorderEvent();
     audio_recorder_status = false;
     return QString("RPRT 0\n");
+}
+
+/* Set the LNB LO value */
+QString RemoteControl::cmd_lnb_lo(QStringList cmdlist)
+{
+    if(cmdlist.size() == 2)
+    {
+        bool ok;
+        qint64 freq = cmdlist[1].toLongLong(&ok);
+
+        if (ok)
+        {
+            rc_lnb_lo_mhz = freq / 1e6;
+            emit newLnbLo(rc_lnb_lo_mhz);
+            return QString("RPRT 0\n");
+        }
+
+        return QString("RPRT 1\n");
+    }
+    else
+    {
+        return QString("%1\n").arg((qint64)(rc_lnb_lo_mhz * 1e6));
+    }
 }
 
 /*

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -82,6 +82,7 @@ public:
 public slots:
     void setNewFrequency(qint64 freq);
     void setFilterOffset(qint64 freq);
+    void setLnbLo(double freq_mhz);
     void setBandwidth(qint64 bw);
     void setSignalLevel(float level);
     void setMode(int mode);
@@ -93,6 +94,7 @@ public slots:
 signals:
     void newFrequency(qint64 freq);
     void newFilterOffset(qint64 offset);
+    void newLnbLo(double freq_mhz);
     void newMode(int mode);
     void newPassband(int passband);
     void newSquelchLevel(double level);
@@ -113,6 +115,7 @@ private:
     qint64      rc_freq;
     qint64      rc_filter_offset;
     qint64      bw_half;
+    double      rc_lnb_lo_mhz;     /*!< Current LNB LO freq in MHz */
 
     int         rc_mode;           /*!< Current mode. */
     int         rc_passband_lo;    /*!< Current low cutoff. */
@@ -143,6 +146,7 @@ private:
     QString     cmd_get_info() const;
     QString     cmd_AOS();
     QString     cmd_LOS();
+    QString     cmd_lnb_lo(QStringList cmdlist);
     QString     cmd_dump_state() const;
 };
 

--- a/src/qtgui/dockinputctl.h
+++ b/src/qtgui/dockinputctl.h
@@ -70,7 +70,6 @@ public:
     void    readSettings(QSettings * settings);
     void    saveSettings(QSettings * settings);
 
-    void    setLnbLo(double freq_mhz);
     double  lnbLo();
     void    readLnbLoFromSettings(QSettings * settings);
 
@@ -114,6 +113,9 @@ signals:
     void ignoreLimitsChanged(bool ignore);
     void antennaSelected(QString antenna);
     void freqCtrlResetChanged(bool enabled);
+
+public slots:
+    void setLnbLo(double freq_mhz);
 
 private slots:
     void on_lnbSpinBox_valueChanged(double value);


### PR DESCRIPTION
Addresses #547. Adds `LNB_LO` as a command. Updated documentation.

Example:
    
    LNB_LO
    0
    LNB_LO 1000000
    RPRT 0
    LNB_LO
    1000000

Comments:

The value is handled in the app as a `double`, but the remote command exposes an integer frequency to match up with the behavior of the `f` command.

When setting the frequency `RPRT 0` or `RPRT 1` is returned as other commands do even though this is not a hamlib command. Figured I'd try to stay consistent.

Using this remote command will __not__ change the tuner configuration at runtime (at least as tested with my RTL-SDR). This is desired behavior for me but may not be for others. I'd be willing to refactor the app a bit to separate the concepts of the tuner offset and the display offset but I decided the work is outside the scope of this PR.