### PR TITLE
sdrplay2: allow min 62500 samples/sec

### DIFF
--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -531,6 +531,11 @@ void CIoConfig::updateInputSampleRates(int rate)
     }
     else if (ui->inDevEdit->text().contains("sdrplay"))
     {
+        ui->inSrCombo->addItem("62500");
+        ui->inSrCombo->addItem("125000");
+        ui->inSrCombo->addItem("250000");
+        ui->inSrCombo->addItem("500000");
+        ui->inSrCombo->addItem("1000000");
         ui->inSrCombo->addItem("2000000");
         ui->inSrCombo->addItem("2048000");
         ui->inSrCombo->addItem("3000000");
@@ -543,8 +548,8 @@ void CIoConfig::updateInputSampleRates(int rate)
         ui->inSrCombo->addItem("10000000");
         if (rate > 0)
         {
-            if (rate < 2000000)
-                rate = 2000000;
+            if (rate < 62500)
+                rate = 62500;
             if (rate > 10000000)
                 rate = 10000000;
             ui->inSrCombo->insertItem(0, QString("%1").arg(rate));

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -537,7 +537,6 @@ void CIoConfig::updateInputSampleRates(int rate)
         ui->inSrCombo->addItem("500000");
         ui->inSrCombo->addItem("1000000");
         ui->inSrCombo->addItem("2000000");
-        ui->inSrCombo->addItem("2048000");
         ui->inSrCombo->addItem("3000000");
         ui->inSrCombo->addItem("4000000");
         ui->inSrCombo->addItem("5000000");
@@ -556,7 +555,7 @@ void CIoConfig::updateInputSampleRates(int rate)
             ui->inSrCombo->setCurrentIndex(0);
         }
         else
-            ui->inSrCombo->setCurrentIndex(1); // select 2048 kHz
+            ui->inSrCombo->setCurrentIndex(5); // select 2 MHz
     }
     else if (ui->inDevEdit->text().contains("lime"))
     {


### PR DESCRIPTION
SDRplay can reach 2MS/s / 32 with decimation, so lower bound should be 62500S/s. Previous PR limited to 2MS/s.