### PR TITLE
Add backspace key

### DIFF
--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -513,12 +513,6 @@ void CFreqCtrl::keyPressEvent(QKeyEvent *event)
         fSkipMsg = true;
         break;
     case Qt::Key_Backspace:
-        if (m_ActiveEditDigit != -1)
-        {
-            moveCursorLeft();
-            fSkipMsg = true;
-        }
-        break;
     case Qt::Key_Left:
         if (m_ActiveEditDigit != -1)
         {

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -512,6 +512,13 @@ void CFreqCtrl::keyPressEvent(QKeyEvent *event)
         moveCursorRight();
         fSkipMsg = true;
         break;
+    case Qt::Key_Backspace:
+        if (m_ActiveEditDigit != -1)
+        {
+            moveCursorLeft();
+            fSkipMsg = true;
+        }
+        break;
     case Qt::Key_Left:
         if (m_ActiveEditDigit != -1)
         {


### PR DESCRIPTION
Backspace key has the same function as the left arrow key. When typing in a frequency using the number keys, I keep accidentally hitting the backspace key expecting it will move the digit it is editing one backwards (the same thing the left arrow does).