### PR TITLE
Delete remote control socket after closing it

### DIFF
--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -79,8 +79,11 @@ void RemoteControl::start_server()
 /*! \brief Stop the server. */
 void RemoteControl::stop_server()
 {
-    if (rc_socket != 0)
+    if (rc_socket != 0) {
         rc_socket->close();
+        delete rc_socket;
+        rc_socket = 0;
+    }
 
     if (rc_server.isListening())
         rc_server.close();
@@ -162,6 +165,11 @@ void RemoteControl::setHosts(QStringList hosts)
  */
 void RemoteControl::acceptConnection()
 {
+    if (rc_socket)
+    {
+        rc_socket->close();
+        delete rc_socket;
+    }
     rc_socket = rc_server.nextPendingConnection();
 
     // check if host is allowed
@@ -171,6 +179,8 @@ void RemoteControl::acceptConnection()
         std::cout << "*** Remote connection attempt from " << address.toStdString()
                   << " (not in allowed list)" << std::endl;
         rc_socket->close();
+        delete rc_socket;
+        rc_socket = 0;
     }
     else
     {
@@ -237,6 +247,8 @@ void RemoteControl::startRead()
     {
         // FIXME: for now we assume 'close' command
         rc_socket->close();
+        delete rc_socket;
+        rc_socket = 0;
         return;
     }
     else


### PR DESCRIPTION
Fixes memory leak discussed on the mailing list:
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/gqrx/1-9GZa7gQeA/lnN47mBRCAAJ

The Qt5 documentation also suggests deleting the socket:
http://doc.qt.io/qt-5/qtcpserver.html#nextPendingConnection