### PR TITLE
Fix crash in remote_control q command

### DIFF
--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -81,7 +81,7 @@ void RemoteControl::stop_server()
 {
     if (rc_socket != 0) {
         rc_socket->close();
-        delete rc_socket;
+        rc_socket->deleteLater();
         rc_socket = 0;
     }
 
@@ -168,7 +168,7 @@ void RemoteControl::acceptConnection()
     if (rc_socket)
     {
         rc_socket->close();
-        delete rc_socket;
+        rc_socket->deleteLater();
     }
     rc_socket = rc_server.nextPendingConnection();
 
@@ -179,7 +179,7 @@ void RemoteControl::acceptConnection()
         std::cout << "*** Remote connection attempt from " << address.toStdString()
                   << " (not in allowed list)" << std::endl;
         rc_socket->close();
-        delete rc_socket;
+        rc_socket->deleteLater();
         rc_socket = 0;
     }
     else
@@ -247,7 +247,7 @@ void RemoteControl::startRead()
     {
         // FIXME: for now we assume 'close' command
         rc_socket->close();
-        delete rc_socket;
+        rc_socket->deleteLater();
         rc_socket = 0;
         return;
     }


### PR DESCRIPTION
Gqrx 2.11.4 crashes when I am using remote control from Fldigi or WSJTX, and I quit from that app.
I am using MacOS 10.13.4.

To reproduce it, start Gqrx and configure WSJTX or Fldigi to use "Hamlib NET rigctl".  Quit from WSJTX or Fldigi, and Gqrx crashes.  It may not happen every time, but it is quite frequent for me.

I am able to reproduce it by sending 'q' to the remote control port.  Start Gqrx and enable the remote control port.  Then send this command.  It may take several tries.

```
echo q | nc 127.0.0.1 7356
```

This problem started after commit 74931e8, "Delete remote control socket after closing it".

If I revert those changes, then it no longer crashes.

I see this stack trace in the crash logs.  I think that the event loop is trying to send the readyRead signal to the deleted socket. The readyRead signal is connected to the startRead slot.
```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   org.qt-project.QtCore         	0x000000010c3a5754 QMetaObject::activate(QObject*, int, int, void**) + 260
1   org.qt-project.QtCore         	0x000000010c2b664e QIODevice::channelReadyRead(int) + 62
2   org.qt-project.QtNetwork      	0x000000010aa46a2f 0x10a999000 + 711215
3   org.qt-project.QtNetwork      	0x000000010aa58360 0x10a999000 + 783200
4   org.qt-project.QtWidgets      	0x000000010b5b7752 QApplicationPrivate::notify_helper(QObject*, QEvent*) + 306
5   org.qt-project.QtWidgets      	0x000000010b5b8a6f QApplication::notify(QObject*, QEvent*) + 383
6   org.qt-project.QtCore         	0x000000010c374f7f QCoreApplication::notifyInternal2(QObject*, QEvent*) + 159
```
I fixed it by changing 

```
   delete rc_socket;
```

to

```
   rc_socket->deleteLater();
```

The [deleteLater](http://doc.qt.io/qt-5/qobject.html#deleteLater) method schedules deletion to be done by the event loop.  
This allows the event loop to handle pending signals before deleting the socket.

I am now able to send 10000 q commands without crashing, and it also continues to run when I quit from Fldigi or WSJTX.
```
repeat 10000 echo q | nc 127.0.0.1 7356
```
