### PR TITLE
Replace deprecated qt5_use_modules macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 2.8.11)
 
 # Project name
 project(gqrx)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,10 +58,13 @@ endif(WIN32)
 #######################################################################################################################
 # Build the program
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCE} ${UIS_HDRS} ${RESOURCES_LIST})
-qt5_use_modules(${PROJECT_NAME} Core Network Widgets Svg)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 # The pulse libraries are only needed on Linux. On other platforms they will not be found, so having them here is fine.
 target_link_libraries(${PROJECT_NAME}
+    Qt5::Core
+    Qt5::Network
+    Qt5::Widgets
+    Qt5::Svg
     ${Boost_LIBRARIES}
     ${GNURADIO_ALL_LIBRARIES}
     ${GNURADIO_OSMOSDR_LIBRARIES}


### PR DESCRIPTION
The `qt5_use_modules` macro was removed in Qt 5.11, causing the build to fail.