### PR TITLE
Fix spelling of FFT

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1287,7 +1287,7 @@ void MainWindow::iqFftTimeout()
         d_iirFftData[i] += d_fftAvg * (d_realFftData[i] - d_iirFftData[i]);
     }
 
-    ui->plotter->setNewFttData(d_iirFftData, d_realFftData, fftsize);
+    ui->plotter->setNewFftData(d_iirFftData, d_realFftData, fftsize);
 }
 
 /** Audio FFT plot timeout. */
@@ -1332,7 +1332,7 @@ void MainWindow::audioFftTimeout()
         d_realFftData[i] = 10.0 * log10f(pwr + 1.0e-20);
     }
 
-    uiDockAudio->setNewFttData(d_realFftData, fftsize);
+    uiDockAudio->setNewFftData(d_realFftData, fftsize);
 }
 
 /** RDS message display timeout. */

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -87,7 +87,6 @@ private:
     float          *d_realFftData;
     float          *d_iirFftData;
     float          *d_pwrFftData;
-    //double *d_audioFttData;
     float           d_fftAvg;      /*!< FFT averaging parameter set by user (not the true gain). */
 
     bool d_have_audio;  /*!< Whether we have audio (i.e. not with demod_off. */

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -93,9 +93,9 @@ void DockAudio::setFftRange(quint64 minf, quint64 maxf)
     }
 }
 
-void DockAudio::setNewFttData(float *fftData, int size)
+void DockAudio::setNewFftData(float *fftData, int size)
 {
-    ui->audioSpectrum->setNewFttData(fftData, size);
+    ui->audioSpectrum->setNewFftData(fftData, size);
 }
 
 /*! \brief Set new audio gain.

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -51,7 +51,7 @@ public:
     ~DockAudio();
 
     void setFftRange(quint64 minf, quint64 maxf);
-    void setNewFttData(float *fftData, int size);
+    void setNewFftData(float *fftData, int size);
     int  fftRate() const { return 10; }
 
     void setAudioGain(int gain);

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1113,7 +1113,7 @@ void CPlotter::draw()
  * When FFT data is set using this method, the same data will be used for both the
  * pandapter and the waterfall.
  */
-void CPlotter::setNewFttData(float *fftData, int size)
+void CPlotter::setNewFftData(float *fftData, int size)
 {
     /** FIXME **/
     if (!m_Running)
@@ -1136,7 +1136,7 @@ void CPlotter::setNewFttData(float *fftData, int size)
  * waterfall.
  */
 
-void CPlotter::setNewFttData(float *fftData, float *wfData, int size)
+void CPlotter::setNewFftData(float *fftData, float *wfData, int size)
 {
     /** FIXME **/
     if (!m_Running)

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -39,8 +39,8 @@ public:
     void setTooltipsEnabled(bool enabled) { m_TooltipsEnabled = enabled; }
     void setBookmarksEnabled(bool enabled) { m_BookmarksEnabled = enabled; }
 
-    void setNewFttData(float *fftData, int size);
-    void setNewFttData(float *fftData, float *wfData, int size);
+    void setNewFftData(float *fftData, int size);
+    void setNewFftData(float *fftData, float *wfData, int size);
 
     void setCenterFreq(quint64 f);
     void setFreqUnits(qint32 unit) { m_FreqUnits = unit; }


### PR DESCRIPTION
FFT was spelled as FTT in a few places.