### PR TITLE
Add buttons to reset, increase and decrease audio gain

### DIFF
--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -115,7 +115,6 @@ int  DockAudio::audioGain()
     return ui->audioGainSlider->value();
 }
 
-
 /*! Set FFT plot color. */
 void DockAudio::setFftColor(QColor color)
 {

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -115,6 +115,7 @@ int  DockAudio::audioGain()
     return ui->audioGainSlider->value();
 }
 
+
 /*! Set FFT plot color. */
 void DockAudio::setFftColor(QColor color)
 {
@@ -421,4 +422,20 @@ void DockAudio::setNewUdpHost(const QString &host)
 void DockAudio::setNewUdpPort(int port)
 {
     udp_port = port;
+}
+
+void DockAudio::on_zerodB_clicked()
+{
+    setAudioGain(0);
+}
+
+void DockAudio::on_minus10dB_clicked()
+{
+    setAudioGain(audioGain()-100);
+}
+
+void DockAudio::on_plus10dB_clicked()
+{
+    setAudioGain(audioGain()+100);
+
 }

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -107,7 +107,9 @@ private slots:
     void setNewRecDir(const QString &dir);
     void setNewUdpHost(const QString &host);
     void setNewUdpPort(int port);
-
+    void on_zerodB_clicked();
+    void on_minus10dB_clicked();
+    void on_plus10dB_clicked();
 
 private:
     Ui::DockAudio *ui;

--- a/src/qtgui/dockaudio.ui
+++ b/src/qtgui/dockaudio.ui
@@ -151,6 +151,67 @@
      </layout>
     </item>
     <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0">
+      <item>
+       <widget class="QPushButton" name="minus10dB">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Lower audio gain by 10dB</string>
+        </property>
+        <property name="statusTip">
+         <string>Lower audio gain by 10dB</string>
+        </property>
+        <property name="text">
+         <string>-10dB</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="zerodB">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Reset audio gain to 0dB</string>
+        </property>
+        <property name="statusTip">
+         <string>Reset audio gain to 0dB</string>
+        </property>
+        <property name="text">
+         <string>0dB</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="plus10dB">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Increase audio gain by 10dB</string>
+        </property>
+        <property name="statusTip">
+         <string>Increase audio gain by 10dB</string>
+        </property>
+        <property name="text">
+         <string>+10dB</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+    <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
       <property name="spacing">
        <number>0</number>


### PR DESCRIPTION
Adds a button to set the audio gain to 0db, one to increase it by 10db and one to decrease it by 10db, under the slider
![image](https://user-images.githubusercontent.com/3357750/45932765-c7e28e00-bf81-11e8-8245-ee96ed620a57.png)
