### PR TITLE
Add shortcut. Pressing F moves focus to frequency widget.

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2300,3 +2300,13 @@ void MainWindow::on_actionAddBookmark_triggered()
         ui->plotter->updateOverlay();
     }
 }
+
+void MainWindow::keyPressEvent(QKeyEvent *event)
+{
+    switch (event->key())
+    {
+    case Qt::Key_F:
+        ui->freqCtrl->setFrequencyFocus();
+        break;
+    }
+}

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -32,6 +32,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSvgWidget>
+#include <QKeyEvent>
 
 #include "qtgui/dockrxopt.h"
 #include "qtgui/dockaudio.h"
@@ -120,6 +121,9 @@ private:
 
     // dummy widget to enforce linking to QtSvg
     QSvgWidget      *qsvg_dummy;
+
+protected:
+    void    keyPressEvent(QKeyEvent *);
 
 private:
     void updateHWFrequencyRange(bool ignore_limits);
@@ -229,7 +233,6 @@ private slots:
     void meterTimeout();
     void iqFftTimeout();
     void audioFftTimeout();
-    void rdsTimeout();
-};
+    void rdsTimeout();};
 
 #endif // MAINWINDOW_H

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -483,6 +483,7 @@ void CFreqCtrl::keyPressEvent(QKeyEvent *event)
     // call base class if dont over ride key
     bool      fSkipMsg = false;
     qint64    tmp;
+    uint8_t position = 0;
 
     // qDebug() <<event->key();
 
@@ -847,4 +848,17 @@ void CFreqCtrl::cursorEnd()
         cursor().setPos(mapToGlobal(m_DigitInfo[m_FirstEditableDigit].dQRect.
                                     center()));
     }
+}
+
+void CFreqCtrl::cursorTo(uint8_t position)
+{
+    cursor().setPos(mapToGlobal(m_DigitInfo[position].dQRect.center()));
+}
+
+void CFreqCtrl::setFrequencyFocus()
+{
+    uint8_t position = floor(log10(m_freq));
+    position = (uint8_t)fmax(position, 4);      // restrict min to 100s of kHz
+
+    cursorTo(position);
 }

--- a/src/qtgui/freqctrl.h
+++ b/src/qtgui/freqctrl.h
@@ -56,6 +56,7 @@ signals:
 
 public slots:
     void    setFrequency(qint64 freq);
+    void    setFrequencyFocus();
 
 protected:
     void    paintEvent(QPaintEvent *);
@@ -77,6 +78,7 @@ private:
     void    clearFreq();
     void    cursorHome();
     void    cursorEnd();
+    void    cursorTo(uint8_t position);
     void    moveCursorLeft();
     void    moveCursorRight();
     bool    inRect(QRect &rect, QPoint &point);


### PR DESCRIPTION
For a long time I wanted to have a shortkey for setting frequency, so I didn't have to use mouse. It probably could be done better, but this solution works and it makes my life easier. I hope you can merge it like it is or make it better. 

-Andrei