### PR TITLE
Touch-Friendly UI Tweaks (Separate small-screen UI?)

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -353,8 +353,11 @@ MainWindow::~MainWindow()
         else
             m_settings->remove("gui/hide_toolbar");
 
+        if(stateBeforeMinimize != Q_NULLPTR)
+            restoreState(stateBeforeMinimize);
         m_settings->setValue("gui/geometry", saveGeometry());
         m_settings->setValue("gui/state", saveState());
+        m_settings->setValue("gui/showmenu", ui->actionShowRightDock->isChecked());
 
         // save session
         storeSession();
@@ -463,6 +466,10 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
                                           saveGeometry()).toByteArray());
         restoreState(m_settings->value("gui/state", saveState()).toByteArray());
     }
+
+    // Restore settings menu hide/show state
+    bool_val = m_settings->value("gui/showmenu", false).toBool();
+    ui->actionShowRightDock->setChecked(bool_val);
 
     QString indev = m_settings->value("input/device", "").toString();
     if (!indev.isEmpty())
@@ -2298,5 +2305,22 @@ void MainWindow::on_actionAddBookmark_triggered()
         uiDockBookmarks->updateTags();
         uiDockBookmarks->updateBookmarks();
         ui->plotter->updateOverlay();
+    }
+}
+
+// Hide/show the right-hand settings menu, to give a larger FFT viewing area
+void MainWindow::on_actionShowRightDock_toggled(bool state)
+{
+    if(state){
+        if(stateBeforeMinimize != Q_NULLPTR)
+            restoreState(stateBeforeMinimize);
+    }
+    else{
+        //Save what the dock area looks like, then hide all dock widgets
+        stateBeforeMinimize = saveState();
+        for(QDockWidget* dw: findChildren<QDockWidget *>()){
+            if(dockWidgetArea(dw) == Qt::RightDockWidgetArea)
+                dw->hide();
+        }
     }
 }

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -121,6 +121,8 @@ private:
     // dummy widget to enforce linking to QtSvg
     QSvgWidget      *qsvg_dummy;
 
+    QByteArray stateBeforeMinimize;
+
 private:
     void updateHWFrequencyRange(bool ignore_limits);
     void updateFrequencyRange();
@@ -230,6 +232,7 @@ private slots:
     void iqFftTimeout();
     void audioFftTimeout();
     void rdsTimeout();
+    void on_actionShowRightDock_toggled(bool state);
 };
 
 #endif // MAINWINDOW_H

--- a/src/applications/gqrx/mainwindow.ui
+++ b/src/applications/gqrx/mainwindow.ui
@@ -86,8 +86,8 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>5</width>
-           <height>15</height>
+           <width>27</width>
+           <height>37</height>
           </size>
          </property>
         </spacer>
@@ -195,7 +195,7 @@
      <x>0</x>
      <y>0</y>
      <width>521</width>
-     <height>19</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -273,6 +273,7 @@
    <addaction name="separator"/>
    <addaction name="actionFullScreen"/>
    <addaction name="separator"/>
+   <addaction name="actionShowRightDock"/>
   </widget>
   <widget class="QStatusBar" name="statusBar">
    <property name="enabled">
@@ -539,6 +540,25 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+W</string>
+   </property>
+  </action>
+  <action name="actionShowRightDock">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../../resources/icons.qrc">
+     <normaloff>:/icons/icons/info.svg</normaloff>
+     <normalon>:/icons/icons/info.svg</normalon>:/icons/icons/info.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Show Menus</string>
+   </property>
+   <property name="toolTip">
+    <string>Show/Hide settings menu</string>
    </property>
   </action>
  </widget>

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -54,6 +54,7 @@ CFreqCtrl::CFreqCtrl(QWidget *parent) :
     setFocusPolicy(Qt::StrongFocus);
     setMouseTracking(true);
     m_BkColor = QColor(0x1F, 0x1D, 0x1D, 0xFF);
+    m_InactiveColor = QColor(0x60, 0x60, 0x60, 0xFF);
     m_DigitColor = QColor(0xFF, 0xFF, 0xFF, 0xFF);
     m_HighlightColor = QColor(0x5A, 0x5A, 0x5A, 0xFF);
     m_UnitsColor = Qt::gray;
@@ -645,7 +646,7 @@ void CFreqCtrl::drawDigits(QPainter &Painter)
                 Painter.fillRect(m_DigitInfo[i].dQRect, m_BkColor);
 
             if (i >= m_LeadZeroPos)
-                Painter.setPen(m_BkColor);
+                Painter.setPen(m_InactiveColor);
             else
                 Painter.setPen(m_DigitColor);
 

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -54,7 +54,7 @@ CFreqCtrl::CFreqCtrl(QWidget *parent) :
     setFocusPolicy(Qt::StrongFocus);
     setMouseTracking(true);
     m_BkColor = QColor(0x1F, 0x1D, 0x1D, 0xFF);
-    m_InactiveColor = QColor(0x60, 0x60, 0x60, 0xFF);
+    m_InactiveColor = QColor(0x43, 0x43, 0x43, 0xFF);
     m_DigitColor = QColor(0xFF, 0xFF, 0xFF, 0xFF);
     m_HighlightColor = QColor(0x5A, 0x5A, 0x5A, 0xFF);
     m_UnitsColor = Qt::gray;

--- a/src/qtgui/freqctrl.h
+++ b/src/qtgui/freqctrl.h
@@ -107,6 +107,7 @@ private:
 
     QColor      m_DigitColor;
     QColor      m_BkColor;
+    QColor      m_InactiveColor;
     QColor      m_UnitsColor;
     QColor      m_HighlightColor;
 


### PR DESCRIPTION
I've found gqrx running on a Raspberry Pi touchscreen to be a nice and portable RF spectrum analyzer. However, those displays generally don't have much screen area, and don't seem to play particularly nicely with the current desktop-centric interface. I've been working on some UI tweaks to make the interface more touch-friendly, but I'm not sure if they would be applicable to larger screens/non-touch screens. Perhaps a separate branch aimed at low-res/portable displays is in order?

So far, the tweaks I've made allow the settings docks to be hidden (to give the FFT/waterfall more screen space) and make it easier to see where to tap on the frequency control.