### PR TITLE
Add second resampler for raw IQ demod

### DIFF
--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -124,7 +124,8 @@ private:
     gr::blocks::complex_to_real::sptr   demod_ssb;  /*!< SSB demodulator. */
     rx_demod_fm_sptr          demod_fm;   /*!< FM demodulator. */
     rx_demod_am_sptr          demod_am;   /*!< AM demodulator. */
-    resampler_ff_sptr         audio_rr;   /*!< Audio resampler. */
+    resampler_ff_sptr         audio_rr0;  /*!< Audio resampler. */
+    resampler_ff_sptr         audio_rr1;  /*!< Audio resampler. */
 
     gr::basic_block_sptr      demod;    // dummy pointer used for simplifying reconf
 };


### PR DESCRIPTION
Fixes #684 

The second resampler is only used when IQ demod is selected. For all other modes only `audio_rr0` is used like before.