### PR TITLE
Add mute button

### DIFF
--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -20,6 +20,7 @@
  * the Free Software Foundation, Inc., 51 Franklin Street,
  * Boston, MA 02110-1301, USA.
  */
+#include <cmath>
 #include <QDebug>
 #include <QDateTime>
 #include <QDir>
@@ -44,6 +45,7 @@ DockAudio::DockAudio(QWidget *parent) :
 
 #ifdef Q_OS_LINUX
     // buttons can be smaller than 50x32
+    ui->audioMuteButton->setMinimumSize(48, 24);
     ui->audioStreamButton->setMinimumSize(48, 24);
     ui->audioRecButton->setMinimumSize(48, 24);
     ui->audioPlayButton->setMinimumSize(48, 24);
@@ -170,7 +172,8 @@ void DockAudio::on_audioGainSlider_valueChanged(int value)
 
     // update dB label
     ui->audioGainDbLabel->setText(QString("%1 dB").arg(gain, 5, 'f', 1));
-    emit audioGainChanged(gain);
+    if (!ui->audioMuteButton->isChecked())
+        emit audioGainChanged(gain);
 }
 
 /*! \brief Streaming button clicked.
@@ -249,6 +252,21 @@ void DockAudio::on_audioPlayButton_clicked(bool checked)
 void DockAudio::on_audioConfButton_clicked()
 {
     audioOptions->show();
+}
+
+/*! \brief Mute audio. */
+void DockAudio::on_audioMuteButton_clicked(bool checked)
+{
+    if (checked)
+    {
+        emit audioGainChanged(-INFINITY);
+    }
+    else
+    {
+        int value = ui->audioGainSlider->value();
+        float gain = float(value) / 10.0;
+        emit audioGainChanged(gain);
+    }
 }
 
 /*! \brief Set status of audio record button. */

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -102,6 +102,7 @@ private slots:
     void on_audioRecButton_clicked(bool checked);
     void on_audioPlayButton_clicked(bool checked);
     void on_audioConfButton_clicked();
+    void on_audioMuteButton_clicked(bool checked);
     void setNewPandapterRange(int min, int max);
     void setNewWaterfallRange(int min, int max);
     void setNewRecDir(const QString &dir);

--- a/src/qtgui/dockaudio.ui
+++ b/src/qtgui/dockaudio.ui
@@ -156,7 +156,47 @@
        <number>0</number>
       </property>
       <item>
+       <widget class="QPushButton" name="audioMuteButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>32</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Mute audio output</string>
+        </property>
+        <property name="statusTip">
+         <string>Mute audio output</string>
+        </property>
+        <property name="text">
+         <string>Mute</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="audioStreamButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="minimumSize">
          <size>
           <width>50</width>


### PR DESCRIPTION
Adds the mute button requested in #689 

Enabling the mute button sets the audio gain to -infinity, which results in a multiplier value 0 in the receiver.

![mute_button](https://user-images.githubusercontent.com/2362689/59071372-9ebf1f00-88be-11e9-8879-bd3e31dcaa46.png)
