### PR TITLE
Port to Gnuradio 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,14 +99,8 @@ endfunction(add_source_files)
 
 # 3rd Party Dependency Stuff
 find_package(Qt5 COMPONENTS Core Network Widgets Svg REQUIRED)
-find_package(Boost COMPONENTS system program_options REQUIRED)
-set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT PMT)
-find_package(Gnuradio REQUIRED)
+find_package(Gnuradio "3.8" REQUIRED COMPONENTS analog audio blocks digital filter fft)
 find_package(Gnuradio-osmosdr REQUIRED)
-
-if(NOT GNURADIO_RUNTIME_FOUND)
-    message(FATAL_ERROR "GnuRadio Runtime required to compile gqrx")
-endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     if(NOT LINUX_AUDIO_BACKEND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 2.8.11)
 
 # Project name
 project(gqrx)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,8 +65,10 @@ target_link_libraries(${PROJECT_NAME}
     Qt5::Network
     Qt5::Widgets
     Qt5::Svg
-    ${Boost_LIBRARIES}
-    ${GNURADIO_ALL_LIBRARIES}
+    gnuradio::gnuradio-analog
+    gnuradio::gnuradio-blocks
+    gnuradio::gnuradio-digital
+    gnuradio::gnuradio-filter
     ${GNURADIO_OSMOSDR_LIBRARIES}
     ${PULSEAUDIO_LIBRARY}
     ${PULSE-SIMPLE}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,10 +58,13 @@ endif(WIN32)
 #######################################################################################################################
 # Build the program
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_SOURCE} ${UIS_HDRS} ${RESOURCES_LIST})
-qt5_use_modules(${PROJECT_NAME} Core Network Widgets Svg)
 set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 11)
 # The pulse libraries are only needed on Linux. On other platforms they will not be found, so having them here is fine.
 target_link_libraries(${PROJECT_NAME}
+    Qt5::Core
+    Qt5::Network
+    Qt5::Widgets
+    Qt5::Svg
     ${Boost_LIBRARIES}
     ${GNURADIO_ALL_LIBRARIES}
     ${GNURADIO_OSMOSDR_LIBRARIES}

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -28,7 +28,6 @@
 
 #include <iostream>
 
-#include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
 #include <osmosdr/source.h>

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -23,10 +23,10 @@
 #ifndef RECEIVER_H
 #define RECEIVER_H
 
-#include <gnuradio/analog/sig_source_c.h>
+#include <gnuradio/analog/sig_source.h>
 #include <gnuradio/blocks/file_sink.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
-#include <gnuradio/blocks/multiply_cc.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/blocks/multiply.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/blocks/wavfile_sink.h>
 #include <gnuradio/blocks/wavfile_source.h>

--- a/src/dsp/correct_iq_cc.h
+++ b/src/dsp/correct_iq_cc.h
@@ -28,7 +28,7 @@
 #include <gnuradio/blocks/float_to_complex.h>
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/single_pole_iir_filter_cc.h>
-#include <gnuradio/blocks/sub_cc.h>
+#include <gnuradio/blocks/sub.h>
 
 class dc_corr_cc;
 class iq_swap_cc;

--- a/src/dsp/filter/fir_decim.cpp
+++ b/src/dsp/filter/fir_decim.cpp
@@ -24,7 +24,6 @@
 #include <cstdio>
 #include <vector>
 
-#include <gnuradio/filter/fir_filter_ccf.h>
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/io_signature.h>
 

--- a/src/dsp/filter/fir_decim.h
+++ b/src/dsp/filter/fir_decim.h
@@ -22,7 +22,7 @@
  */
 #pragma once
 
-#include <gnuradio/filter/fir_filter_ccf.h>
+#include <gnuradio/filter/fir_filter_blk.h>
 #include <gnuradio/hier_block2.h>
 
 class fir_decim_cc;

--- a/src/dsp/lpf.h
+++ b/src/dsp/lpf.h
@@ -25,7 +25,7 @@
 
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/fir_filter_fff.h>
+#include <gnuradio/filter/fir_filter_blk.h>
 
 
 class lpf_ff;

--- a/src/dsp/rx_filter.h
+++ b/src/dsp/rx_filter.h
@@ -24,8 +24,8 @@
 #define RX_FILTER_H
 
 #include <gnuradio/hier_block2.h>
-#include <gnuradio/filter/fir_filter_ccc.h>
-#include <gnuradio/filter/freq_xlating_fir_filter_ccc.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
 
 
 #define RX_FILTER_MIN_WIDTH 100  /*! Minimum width of filter */

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -24,11 +24,8 @@
 #define RX_RDS_H
 
 #include <gnuradio/hier_block2.h>
-#include <gnuradio/filter/fir_filter_ccc.h>
-#include <gnuradio/filter/fir_filter_ccf.h>
-#include <gnuradio/filter/fir_filter_fff.h>
-#include <gnuradio/filter/freq_xlating_fir_filter_fcf.h>
-#include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
 #include <gnuradio/digital/constellation_receiver_cb.h>
 #include <gnuradio/blocks/keep_one_in_n.h>
 #include <gnuradio/digital/diff_decoder_bb.h>

--- a/src/dsp/stereo_demod.h
+++ b/src/dsp/stereo_demod.h
@@ -26,14 +26,12 @@
 
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/firdes.h>
-#include <gnuradio/filter/fir_filter_fcc.h>
-#include <gnuradio/filter/fir_filter_fff.h>
+#include <gnuradio/filter/fir_filter_blk.h>
 #include <gnuradio/analog/pll_refout_cc.h>
-#include <gnuradio/blocks/multiply_cc.h>
-#include <gnuradio/blocks/multiply_ff.h>
-#include <gnuradio/blocks/multiply_const_ff.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/blocks/multiply_const.h>
 #include <gnuradio/blocks/complex_to_imag.h>
-#include <gnuradio/blocks/add_ff.h>
+#include <gnuradio/blocks/add_blk.h>
 #include <vector>
 #include "dsp/lpf.h"
 #include "dsp/resampler_xx.h"


### PR DESCRIPTION
- Use new syntax for required GR components
- Use gnuradio::gnuradio-* instead of GNURADIO_ALL_LIBRARIES
- Update sources for renamed/consolidated headers