### PR TITLE
Build for GNU Radio 3.7 and 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,14 +105,18 @@ endif()
 
 # 3rd Party Dependency Stuff
 find_package(Qt5 COMPONENTS Core Network Widgets Svg REQUIRED)
-find_package(Boost COMPONENTS system program_options REQUIRED)
-set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT PMT)
-find_package(Gnuradio REQUIRED)
 find_package(Gnuradio-osmosdr REQUIRED)
 
+set(GR_REQUIRED_COMPONENTS RUNTIME ANALOG AUDIO BLOCKS DIGITAL FILTER FFT PMT)
+find_package(Gnuradio REQUIRED COMPONENTS analog audio blocks digital filter fft)
 
-if(NOT GNURADIO_RUNTIME_FOUND)
+if(NOT Gnuradio_FOUND)
     message(FATAL_ERROR "GnuRadio Runtime required to compile gqrx")
+endif()
+
+if(Gnuradio_VERSION VERSION_LESS "3.8")
+    add_definitions(-DGNURADIO_37)
+    find_package(Boost COMPONENTS system program_options REQUIRED)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,20 @@ if(NOT Gnuradio_FOUND)
     message(FATAL_ERROR "GnuRadio Runtime required to compile gqrx")
 endif()
 
+
+# Pass the GNU Radio version as 0xMMNNPP BCD.
+math(EXPR GNURADIO_BCD_VERSION
+    "(${Gnuradio_VERSION_MAJOR} / 10) << 20 |
+     (${Gnuradio_VERSION_MAJOR} % 10) << 16 |
+     (${Gnuradio_VERSION_MINOR} / 10) << 12 |
+     (${Gnuradio_VERSION_MINOR} % 10) <<  8 |
+     (${Gnuradio_VERSION_PATCH} / 10) <<  4 |
+     (${Gnuradio_VERSION_PATCH} % 10) <<  0
+    "
+)
+add_definitions(-DGNURADIO_VERSION=${GNURADIO_BCD_VERSION})
+
 if(Gnuradio_VERSION VERSION_LESS "3.8")
-    add_definitions(-DGNURADIO_37)
     find_package(Boost COMPONENTS system program_options REQUIRED)
 endif()
 

--- a/gqrx.pro
+++ b/gqrx.pro
@@ -62,7 +62,7 @@ isEmpty(PREFIX) {
 }
 
 target.path  = $$PREFIX/bin
-INSTALLS    += target 
+INSTALLS    += target
 
 #CONFIG += debug
 
@@ -262,6 +262,29 @@ PKGCONFIG += gnuradio-analog \
              gnuradio-fft \
              gnuradio-runtime \
              gnuradio-osmosdr
+
+# Detect GNU Radio version and link against log4cpp for 3.8
+GNURADIO_VERSION = $$system(pkg-config --modversion gnuradio-runtime)
+
+GNURADIO_VERSION_MAJOR = $$system(cut -d '.' -f1 <<< $$GNURADIO_VERSION)
+GNURADIO_VERSION_MINOR = $$system(cut -d '.' -f2 <<< $$GNURADIO_VERSION)
+GNURADIO_VERSION_PATCH = $$system(cut -d '.' -f3 <<< $$GNURADIO_VERSION)
+
+GNURADIO_HEX_VERSION = $$system(            \
+  "echo $((                                 \
+    ($$GNURADIO_VERSION_MAJOR / 10) << 20 | \
+    ($$GNURADIO_VERSION_MAJOR % 10) << 16 | \
+    ($$GNURADIO_VERSION_MINOR / 10) << 12 | \
+    ($$GNURADIO_VERSION_MINOR % 10) <<  8 | \
+    ($$GNURADIO_VERSION_PATCH / 10) <<  4 | \
+    ($$GNURADIO_VERSION_PATCH % 10) <<  0   \
+  ))"                                       \
+)
+DEFINES += GNURADIO_VERSION=$$GNURADIO_HEX_VERSION
+
+greaterThan(GNURADIO_VERSION_MINOR, 7) {
+    PKGCONFIG += log4cpp
+}
 
 INCPATH += src/
 

--- a/gqrx.pro
+++ b/gqrx.pro
@@ -266,9 +266,9 @@ PKGCONFIG += gnuradio-analog \
 # Detect GNU Radio version and link against log4cpp for 3.8
 GNURADIO_VERSION = $$system(pkg-config --modversion gnuradio-runtime)
 
-GNURADIO_VERSION_MAJOR = $$system(cut -d '.' -f1 <<< $$GNURADIO_VERSION)
-GNURADIO_VERSION_MINOR = $$system(cut -d '.' -f2 <<< $$GNURADIO_VERSION)
-GNURADIO_VERSION_PATCH = $$system(cut -d '.' -f3 <<< $$GNURADIO_VERSION)
+GNURADIO_VERSION_MAJOR = $$system(echo $$GNURADIO_VERSION | cut -d '.' -f1 -)
+GNURADIO_VERSION_MINOR = $$system(echo $$GNURADIO_VERSION | cut -d '.' -f2 -)
+GNURADIO_VERSION_PATCH = $$system(echo $$GNURADIO_VERSION | cut -d '.' -f3 -)
 
 GNURADIO_HEX_VERSION = $$system(            \
   "echo $((                                 \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,15 @@ target_link_libraries(${PROJECT_NAME}
     ${PORTAUDIO_LIBRARIES}
 )
 
+if(NOT Gnuradio_VERSION VERSION_LESS "3.8")
+    target_link_libraries(${PROJECT_NAME}
+        gnuradio::gnuradio-analog
+        gnuradio::gnuradio-blocks
+        gnuradio::gnuradio-digital
+        gnuradio::gnuradio-filter
+    )
+endif()
+
 #build a win32 app, not a console app
 if (WIN32)
     set(CMAKE_EXE_LINKER_FLAGS "/entry:mainCRTStartup ${CMAKE_EXE_LINKER_FLAGS}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ if(NOT Gnuradio_VERSION VERSION_LESS "3.8")
         gnuradio::gnuradio-blocks
         gnuradio::gnuradio-digital
         gnuradio::gnuradio-filter
+        gnuradio::gnuradio-audio
     )
 endif()
 

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -28,7 +28,10 @@
 
 #include <iostream>
 
+#ifdef GNURADIO_37
 #include <gnuradio/blocks/multiply_const_ff.h>
+#endif
+
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
 #include <osmosdr/source.h>

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -28,7 +28,7 @@
 
 #include <iostream>
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/blocks/multiply_const_ff.h>
 #endif
 

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -23,7 +23,7 @@
 #ifndef RECEIVER_H
 #define RECEIVER_H
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/analog/sig_source_c.h>
 #include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/blocks/multiply_cc.h>

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -23,10 +23,17 @@
 #ifndef RECEIVER_H
 #define RECEIVER_H
 
+#ifdef GNURADIO_37
 #include <gnuradio/analog/sig_source_c.h>
-#include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/blocks/multiply_const_ff.h>
 #include <gnuradio/blocks/multiply_cc.h>
+#else
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/blocks/multiply.h>
+#endif
+
+#include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/blocks/wavfile_sink.h>
 #include <gnuradio/blocks/wavfile_source.h>

--- a/src/dsp/correct_iq_cc.h
+++ b/src/dsp/correct_iq_cc.h
@@ -28,7 +28,12 @@
 #include <gnuradio/blocks/float_to_complex.h>
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/single_pole_iir_filter_cc.h>
+
+#ifdef GNURADIO_37
 #include <gnuradio/blocks/sub_cc.h>
+#else
+#include <gnuradio/blocks/sub.h>
+#endif
 
 class dc_corr_cc;
 class iq_swap_cc;

--- a/src/dsp/correct_iq_cc.h
+++ b/src/dsp/correct_iq_cc.h
@@ -29,7 +29,7 @@
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/single_pole_iir_filter_cc.h>
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/blocks/sub_cc.h>
 #else
 #include <gnuradio/blocks/sub.h>

--- a/src/dsp/filter/fir_decim.cpp
+++ b/src/dsp/filter/fir_decim.cpp
@@ -24,7 +24,7 @@
 #include <cstdio>
 #include <vector>
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/filter/fir_filter_ccf.h>
 #endif
 

--- a/src/dsp/filter/fir_decim.cpp
+++ b/src/dsp/filter/fir_decim.cpp
@@ -24,7 +24,10 @@
 #include <cstdio>
 #include <vector>
 
+#ifdef GNURADIO_37
 #include <gnuradio/filter/fir_filter_ccf.h>
+#endif
+
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/io_signature.h>
 

--- a/src/dsp/filter/fir_decim.h
+++ b/src/dsp/filter/fir_decim.h
@@ -22,7 +22,7 @@
  */
 #pragma once
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/filter/fir_filter_ccf.h>
 #else
 #include <gnuradio/filter/fir_filter_blk.h>

--- a/src/dsp/filter/fir_decim.h
+++ b/src/dsp/filter/fir_decim.h
@@ -22,7 +22,12 @@
  */
 #pragma once
 
+#ifdef GNURADIO_37
 #include <gnuradio/filter/fir_filter_ccf.h>
+#else
+#include <gnuradio/filter/fir_filter_blk.h>
+#endif
+
 #include <gnuradio/hier_block2.h>
 
 class fir_decim_cc;

--- a/src/dsp/lpf.h
+++ b/src/dsp/lpf.h
@@ -26,7 +26,7 @@
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/firdes.h>
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/filter/fir_filter_fff.h>
 #else
 #include <gnuradio/filter/fir_filter_blk.h>

--- a/src/dsp/lpf.h
+++ b/src/dsp/lpf.h
@@ -25,7 +25,12 @@
 
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/firdes.h>
+
+#ifdef GNURADIO_37
 #include <gnuradio/filter/fir_filter_fff.h>
+#else
+#include <gnuradio/filter/fir_filter_blk.h>
+#endif
 
 
 class lpf_ff;

--- a/src/dsp/rx_filter.h
+++ b/src/dsp/rx_filter.h
@@ -25,7 +25,7 @@
 
 #include <gnuradio/hier_block2.h>
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/filter/fir_filter_ccc.h>
 #include <gnuradio/filter/freq_xlating_fir_filter_ccc.h>
 #else

--- a/src/dsp/rx_filter.h
+++ b/src/dsp/rx_filter.h
@@ -24,8 +24,14 @@
 #define RX_FILTER_H
 
 #include <gnuradio/hier_block2.h>
+
+#ifdef GNURADIO_37
 #include <gnuradio/filter/fir_filter_ccc.h>
 #include <gnuradio/filter/freq_xlating_fir_filter_ccc.h>
+#else
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
+#endif
 
 
 #define RX_FILTER_MIN_WIDTH 100  /*! Minimum width of filter */

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -24,11 +24,18 @@
 #define RX_RDS_H
 
 #include <gnuradio/hier_block2.h>
+
+#ifdef GNURADIO_37
 #include <gnuradio/filter/fir_filter_ccc.h>
 #include <gnuradio/filter/fir_filter_ccf.h>
 #include <gnuradio/filter/fir_filter_fff.h>
 #include <gnuradio/filter/freq_xlating_fir_filter_fcf.h>
 #include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
+#else
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
+#endif
+
 #include <gnuradio/digital/constellation_receiver_cb.h>
 #include <gnuradio/blocks/keep_one_in_n.h>
 #include <gnuradio/digital/diff_decoder_bb.h>

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -25,7 +25,7 @@
 
 #include <gnuradio/hier_block2.h>
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/filter/fir_filter_ccc.h>
 #include <gnuradio/filter/fir_filter_ccf.h>
 #include <gnuradio/filter/fir_filter_fff.h>

--- a/src/dsp/stereo_demod.h
+++ b/src/dsp/stereo_demod.h
@@ -26,14 +26,23 @@
 
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/firdes.h>
+
+#ifdef GNURADIO_37
 #include <gnuradio/filter/fir_filter_fcc.h>
 #include <gnuradio/filter/fir_filter_fff.h>
-#include <gnuradio/analog/pll_refout_cc.h>
 #include <gnuradio/blocks/multiply_cc.h>
 #include <gnuradio/blocks/multiply_ff.h>
 #include <gnuradio/blocks/multiply_const_ff.h>
-#include <gnuradio/blocks/complex_to_imag.h>
 #include <gnuradio/blocks/add_ff.h>
+#else
+#include <gnuradio/filter/fir_filter_blk.h>
+#include <gnuradio/blocks/multiply.h>
+#include <gnuradio/blocks/multiply_const.h>
+#include <gnuradio/blocks/add_blk.h>
+#endif
+
+#include <gnuradio/analog/pll_refout_cc.h>
+#include <gnuradio/blocks/complex_to_imag.h>
 #include <vector>
 #include "dsp/lpf.h"
 #include "dsp/resampler_xx.h"

--- a/src/dsp/stereo_demod.h
+++ b/src/dsp/stereo_demod.h
@@ -27,7 +27,7 @@
 #include <gnuradio/hier_block2.h>
 #include <gnuradio/filter/firdes.h>
 
-#ifdef GNURADIO_37
+#if GNURADIO_VERSION < 0x030800
 #include <gnuradio/filter/fir_filter_fcc.h>
 #include <gnuradio/filter/fir_filter_fff.h>
 #include <gnuradio/blocks/multiply_cc.h>


### PR DESCRIPTION
Modifications to source files and CMake files to support builds with GNU Radio 3.7 and 3.8 as discussed in #657 and some pull requests.

There are a few clarifications and possible changes necessary. Some information can be found in the [porting guide](https://wiki.gnuradio.org/index.php/GNU_Radio_3.8_OOT_Module_Porting_Guide).

- [x] Confirm that Boost is discovered and linked correctly.
- [x] Rename the preprocessor macro (e.g. to version number as hex like QT_VERSION)
- [x] Test on more platforms
- [x] Check if the required CMake version has to be changed
- [x] Support qmake

So far I have tested it on Debian Buster for GNU Radio 3.7 and Debian Sid and Arch for GNU Radio 3.8.
Here are the Docker images and scripts I used for testing: https://github.com/alexf91/gqrx-gnuradio-build