### PR TITLE
Reorder readSettings to prevent use of uninitalized values

### DIFF
--- a/src/qtgui/dockinputctl.cpp
+++ b/src/qtgui/dockinputctl.cpp
@@ -61,16 +61,16 @@ void DockInputCtl::readSettings(QSettings * settings)
     setIqBalance(settings->value("input/iq_balance", false).toBool());
     emit iqBalanceChanged(ui->iqBalanceButton->isChecked());
 
+    bool_val = settings->value("input/ignore_limits", false).toBool();
+    setIgnoreLimits(bool_val);
+    emit ignoreLimitsChanged(bool_val);
+
     lnb_lo = settings->value("input/lnb_lo", 0).toLongLong(&conv_ok);
     if (conv_ok)
     {
         setLnbLo(((double)lnb_lo)/1.0e6);
         emit lnbLoChanged(ui->lnbSpinBox->value());
     }
-
-    bool_val = settings->value("input/ignore_limits", false).toBool();
-    setIgnoreLimits(bool_val);
-    emit ignoreLimitsChanged(bool_val);
 
     // Ignore antenna selection if there is only one option
     if (ui->antSelector->count() > 1)


### PR DESCRIPTION
When using a HackRF, Gqrx often crashes on startup with the following error:

`what():  hackrf_set_freq(1.71799e+10) has failed (-1000) Pipe error`

From the error, it's apparent that Gqrx is requesting a frequency (~17 GHz!) which is not valid for the HackRF. In this case, the HackRF returns an error and gr-osmosdr in turn throws an exception.

I did some digging to find out where the invalid frequency comes from, and it turned out to be an uninitialized value: when `MainWindow::updateFrequencyRange` is first called, `d_hw_freq_start` and `d_hw_freq_stop` are uninitialized. Those variables are not set until `MainWindow::updateHWFrequencyRange` is called.

To fix the problem, I've reordered `DockInputCtl::readSettings` so that `DockInputCtl::ignoreLimitsChanged` (which calls `MainWindow::setIgnoreLimits`, which calls `MainWindow::updateHWFrequencyRange`) occurs before `DockInputCtl::lnbLoChanged` (which calls `MainWindow::setLnbLo`, which calls `MainWindow::updateFrequencyRange`).

By running Gqrx in valgrind, I have verified that this eliminates thousands of usages of uninitialized values. The total number of errors reported by valgrind dropped from 4222 to 7.

I suspect this bug may have been the root cause of #504.