### PR TITLE
Ensure d_fftAvg is initialized

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -63,6 +63,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     ui(new Ui::MainWindow),
     d_lnb_lo(0),
     d_hw_freq(0),
+    d_fftAvg(0.25),
     d_have_audio(true),
     dec_afsk1200(0)
 {

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -373,7 +373,7 @@
              <number>100</number>
             </property>
             <property name="value">
-             <number>50</number>
+             <number>75</number>
             </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
From time to time, I run into a bug where the FFT / panadapter does not display. This appears to be the same issue described in #383. I also frequently see participants run into this bug during Capture The Flag competitions involving SDR problems. So far I've been working around the bug by deleting `.config/gqrx/default.conf`.

I dug into this to see what the problem was, and found that the issue can be reliably produced by setting the FFT averaging to 50 in `.config/gqrx/default.conf`:

```
[fft]
averaging=50
```

If the value is different from 50, the problem does not occur. 50 happens to be the default value of the averaging slider:

https://github.com/csete/gqrx/blob/4e6cfd1b7d41d83da97cd88faea4e75d5d4f88f7/src/qtgui/dockfft.ui#L369-L377

The bug occurs because `MainWindow::setIqFftAvg` is the only thing that sets `d_fftAvg`:

https://github.com/csete/gqrx/blob/4e6cfd1b7d41d83da97cd88faea4e75d5d4f88f7/src/applications/gqrx/mainwindow.cpp#L1631-L1635

And the only thing that calls `MainWindow::setIqFftAvg` is `DockFft::on_fftAvgSlider_valueChanged`:

https://github.com/csete/gqrx/blob/4e6cfd1b7d41d83da97cd88faea4e75d5d4f88f7/src/qtgui/dockfft.cpp#L425-L430

So if Gqrx starts up without the value of the slider being changed then `d_fftAvg` is left uninitialized, resulting in undefined behaviour. Valgrind reports hundreds of thousands of warnings in this case, because the following line of code uses the uninitialized `d_fftAvg`:

https://github.com/csete/gqrx/blob/4e6cfd1b7d41d83da97cd88faea4e75d5d4f88f7/src/applications/gqrx/mainwindow.cpp#L1287

To fix the problem, I've set a default value of 0.25 for `d_fftAvg`, which corresponds to the default slider value of 75, which is defined here:

https://github.com/csete/gqrx/blob/4e6cfd1b7d41d83da97cd88faea4e75d5d4f88f7/src/qtgui/dockfft.cpp#L36

In addition, i set the default value of the slider in `dockfft.ui` to match `DEFAULT_FFT_AVG` so that the slider is always updated when the config file has a non-default value.