### PR TITLE
Prevent use of uninitialized values

### DIFF
--- a/src/qtgui/meter.cpp
+++ b/src/qtgui/meter.cpp
@@ -62,8 +62,10 @@ CMeter::CMeter(QWidget *parent) : QFrame(parent)
     m_2DPixmap = QPixmap(0,0);
     m_OverlayPixmap = QPixmap(0,0);
     m_Size = QSize(0,0);
+    m_pixperdb = 0.0f;
     m_Siglevel = 0;
     m_dBFS = MIN_DB;
+    m_Sql = -150.0f;
     m_SqlLevel = 0.0f;
 }
 
@@ -250,4 +252,3 @@ void CMeter::DrawOverlay()
         rect.translate(rwidth, 0);
     }
 }
-


### PR DESCRIPTION
Valgrind reports that `m_Sql` and `m_pixperdb` are used before initialization during Gqrx startup. The `m_Sql` value is read prior to initialization if Gqrx is started without `[receiver] sql_level` set in default.conf, and the `m_pixperdb` value is read prior to initialization if a `sql_level` value is present in default.conf.

I've fixed both errors by setting initial values in the `CMeter` constructor.