### PR TITLE
Avoid naming collision in Debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ if(${CMAKE_BUILD_TYPE} MATCHES "Valgrind")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0")
 endif()
 
+# Workaround for naming collision with log4cpp for Debug builds
+add_definitions(-DLOG4CPP_FIX_ERROR_COLLISION=1)
+
 # Disable debug outputs in release builds
 if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo")
     add_definitions(-DQT_NO_DEBUG_OUTPUT)


### PR DESCRIPTION
GNU Radio 3.8 uses log4cpp for logging and there was a name collision with Debug builds.