### PR TITLE
colormaps: Add White Hot, Black Hot and White Hot compressed

### DIFF
--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -80,6 +80,9 @@ DockFft::DockFft(QWidget *parent) :
     ui->cmapComboBox->addItem(tr("Gqrx"), "gqrx");
     ui->cmapComboBox->addItem(tr("Google Turbo"), "turbo");
     ui->cmapComboBox->addItem(tr("Plasma"), "plasma");
+    ui->cmapComboBox->addItem(tr("White Hot Compressed"), "whitehotcompressed");
+    ui->cmapComboBox->addItem(tr("White Hot"), "whitehot");
+    ui->cmapComboBox->addItem(tr("Black Hot"), "blackhot");
 }
 DockFft::~DockFft()
 {

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1874,4 +1874,31 @@ void CPlotter::setWfColormap(const QString &cmap)
         for (i = 0; i < 256; i++)
             m_ColorTbl[i].setRgb(plasma[i][0], plasma[i][1], plasma[i][2]);
     }
+    else if (cmap.compare("whitehotcompressed",Qt::CaseInsensitive) == 0)
+    {
+        // contributed by @drmpeg @devnulling
+        // for use with high quality spectrum paining
+        // see https://gist.github.com/drmpeg/31a9a7dd6918856aeb60
+        for (int i = 0; i < 256; i++)
+        {
+            if (i < 64)
+            {
+                m_ColorTbl[i].setRgb(i*4, i*4, i*4);
+            }
+            else
+            {
+                m_ColorTbl[i].setRgb(255, 255, 255);
+            }
+        }
+    }
+    else if (cmap.compare("whitehot",Qt::CaseInsensitive) == 0)
+    {
+        for (i = 0; i < 256; i++)
+            m_ColorTbl[i].setRgb(i, i, i);
+    }
+    else if (cmap.compare("blackhot",Qt::CaseInsensitive) == 0)
+    {
+        for (i = 0; i < 256; i++)
+            m_ColorTbl[i].setRgb(255-i, 255-i, 255-i);
+    }
 }


### PR DESCRIPTION
This PR adds 3 new color maps:

- White Hot
- Black Hot
- White Hot Compressed 

White Hot Compressed is useful for making high quality spectrum painting screen caps as shown by @drmpeg 's great write up here: https://gist.github.com/drmpeg/31a9a7dd6918856aeb60 

![gqrx_colors](https://user-images.githubusercontent.com/11846824/73141241-bbb78680-4036-11ea-8094-d5376f986a2e.png)
