### PR TITLE
Fix FFT overlap calculation

### DIFF
--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -540,16 +540,17 @@ void DockFft::on_cmapComboBox_currentIndexChanged(int index)
 /** Update RBW and FFT overlab labels */
 void DockFft::updateInfoLabels(void)
 {
-    float   rate;
+    float   interval_ms;
+    float   interval_samples;
     float   size;
     float   rbw;
     float   ovr;
-    float   sps;
 
     if (m_sample_rate == 0.f)
         return;
 
-    rate = fftRate();
+    interval_ms = 1000 / fftRate();
+    interval_samples = m_sample_rate * (interval_ms / 1000.0);
     size = fftSize();
 
     rbw = m_sample_rate / size;
@@ -560,10 +561,9 @@ void DockFft::updateInfoLabels(void)
     else
         ui->fftRbwLabel->setText(QString("RBW: %1 MHz").arg(1.e-6 * rbw, 0, 'f', 1));
 
-    sps = size * rate;
-    if (sps <= m_sample_rate)
+    if (interval_samples >= size)
         ovr = 0;
     else
-        ovr = 100 * (sps / m_sample_rate - 1.f);
+        ovr = 100 * (1.f - interval_samples / size);
     ui->fftOvrLabel->setText(QString("Overlap: %1%").arg(ovr, 0, 'f', 0));
 }


### PR DESCRIPTION
Gqrx displays the FFT overlap percentage in the FFT Settings pane. I noticed two errors in the calculation:

1. The calculation doesn't take into account the fact that the FFT interval is rounded down to the nearest millisecond. (For instance, when a rate of 60 fps is requested, the FFT display is updated every `floor(1000 / 60)` = 16 milliseconds, and the actual rate is 62.5 fps.)
2. The computed value is the length of the FFT as a fraction of the FFT interval; it should be the other way around.

I've corrected both of these problems and verified that the overlap percentage now stays between 0% and 100%. (Prior to the change, the percentage often exceeds 100%.) I also checked that the calculation works correctly when decimation is used.