### PR TITLE
Increase circular buffer length so FFT updates smoothly

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1732,7 +1732,7 @@ void MainWindow::on_actionDSP_triggered(bool checked)
             ui->plotter->setRunningState(false);
         }
 
-        audio_fft_timer->start(16);
+        audio_fft_timer->start(40);
 
         /* update menu text and button tooltip */
         ui->actionDSP->setToolTip(tr("Stop DSP processing"));

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1732,7 +1732,7 @@ void MainWindow::on_actionDSP_triggered(bool checked)
             ui->plotter->setRunningState(false);
         }
 
-        audio_fft_timer->start(40);
+        audio_fft_timer->start(16);
 
         /* update menu text and button tooltip */
         ui->actionDSP->setToolTip(tr("Stop DSP processing"));

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -120,9 +120,9 @@ receiver::receiver(const std::string input_device,
 
     iq_swap = make_iq_swap_cc(false);
     dc_corr = make_dc_corr_cc(d_quad_rate, 1.0);
-    iq_fft = make_rx_fft_c(8192u, gr::filter::firdes::WIN_HANN);
+    iq_fft = make_rx_fft_c(8192u, d_quad_rate, gr::filter::firdes::WIN_HANN);
 
-    audio_fft = make_rx_fft_f(8192u, gr::filter::firdes::WIN_HANN);
+    audio_fft = make_rx_fft_f(8192u, d_audio_rate, gr::filter::firdes::WIN_HANN);
     audio_gain0 = gr::blocks::multiply_const_ff::make(0.1);
     audio_gain1 = gr::blocks::multiply_const_ff::make(0.1);
 
@@ -345,6 +345,7 @@ double receiver::set_input_rate(double rate)
     d_quad_rate = d_input_rate / (double)d_decim;
     dc_corr->set_sample_rate(d_quad_rate);
     rx->set_quad_rate(d_quad_rate);
+    iq_fft->set_quad_rate(d_quad_rate);
     update_ddc();
     tb->unlock();
 
@@ -399,6 +400,7 @@ unsigned int receiver::set_input_decim(unsigned int decim)
     // update quadrature rate
     dc_corr->set_sample_rate(d_quad_rate);
     rx->set_quad_rate(d_quad_rate);
+    iq_fft->set_quad_rate(d_quad_rate);
     update_ddc();
 
     if (d_decim >= 2)

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -115,7 +115,7 @@ void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 
     /* perform FFT */
     d_cbuf.erase_begin(std::min((unsigned int)(diff.count() * d_quadrate * 1.001), (unsigned int)d_cbuf.size() - d_fftsize));
-    do_fft(d_cbuf.linearize(), d_fftsize);  // FIXME: array_one() and two() may be faster
+    do_fft(d_fftsize);
     //d_cbuf.clear();
 
     /* get FFT data */
@@ -130,18 +130,18 @@ void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
  * Note that this function does not lock the mutex since the caller, get_fft_data()
  * has alrady locked it.
  */
-void rx_fft_c::do_fft(const gr_complex *data_in, unsigned int size)
+void rx_fft_c::do_fft(unsigned int size)
 {
     /* apply window, if any */
     if (d_window.size())
     {
         gr_complex *dst = d_fft->get_inbuf();
         for (unsigned int i = 0; i < size; i++)
-            dst[i] = data_in[i] * d_window[i];
+            dst[i] = d_cbuf[i] * d_window[i];
     }
     else
     {
-        memcpy(d_fft->get_inbuf(), data_in, sizeof(gr_complex)*size);
+        memcpy(d_fft->get_inbuf(), d_cbuf.linearize(), sizeof(gr_complex)*size);
     }
 
     /* compute FFT */
@@ -305,7 +305,7 @@ void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
 
     /* perform FFT */
     d_cbuf.erase_begin(std::min((unsigned int)(diff.count() * d_audiorate * 1.001), (unsigned int)d_cbuf.size() - d_fftsize));
-    do_fft(d_cbuf.linearize(), d_fftsize);  // FIXME: array_one() and two() may be faster
+    do_fft(d_fftsize);
     //d_cbuf.clear();
 
     /* get FFT data */
@@ -320,7 +320,7 @@ void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
  * Note that this function does not lock the mutex since the caller, get_fft_data()
  * has alrady locked it.
  */
-void rx_fft_f::do_fft(const float *data_in, unsigned int size)
+void rx_fft_f::do_fft(unsigned int size)
 {
     gr_complex *dst = d_fft->get_inbuf();
     unsigned int i;
@@ -329,12 +329,12 @@ void rx_fft_f::do_fft(const float *data_in, unsigned int size)
     if (d_window.size())
     {
         for (i = 0; i < size; i++)
-            dst[i] = data_in[i] * d_window[i];
+            dst[i] = d_cbuf[i] * d_window[i];
     }
     else
     {
         for (i = 0; i < size; i++)
-            dst[i] = data_in[i];
+            dst[i] = d_cbuf[i];
     }
 
     /* compute FFT */

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -100,7 +100,7 @@ private:
     boost::circular_buffer<gr_complex> d_cbuf; /*! buffer to accumulate samples. */
     std::chrono::time_point<std::chrono::steady_clock> d_lasttime;
 
-    void do_fft(const gr_complex *data_in, unsigned int size);
+    void do_fft(unsigned int size);
     void set_params();
 
 };
@@ -165,7 +165,7 @@ private:
     boost::circular_buffer<float> d_cbuf; /*! buffer to accumulate samples. */
     std::chrono::time_point<std::chrono::steady_clock> d_lasttime;
 
-    void do_fft(const float *data_in, unsigned int size);
+    void do_fft(unsigned int size);
 
 };
 

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -29,6 +29,7 @@
 #include <gnuradio/gr_complex.h>
 #include <boost/thread/mutex.hpp>
 #include <boost/circular_buffer.hpp>
+#include <chrono>
 
 
 #define MAX_FFT_SIZE 1048576
@@ -48,7 +49,7 @@ typedef boost::shared_ptr<rx_fft_f> rx_fft_f_sptr;
  * of raw pointers, the rx_fft_c constructor is private.
  * make_rx_fft_c is the public interface for creating new instances.
  */
-rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize=4096, int wintype=gr::filter::firdes::WIN_HAMMING);
+rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize=4096, double quad_rate=0, int wintype=gr::filter::firdes::WIN_HAMMING);
 
 
 /*! \brief Block for computing complex FFT.
@@ -65,10 +66,10 @@ rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize=4096, int wintype=gr::filter::f
  */
 class rx_fft_c : public gr::sync_block
 {
-    friend rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize, int wintype);
+    friend rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize, double quad_rate, int wintype);
 
 protected:
-    rx_fft_c(unsigned int fftsize=4096, int wintype=gr::filter::firdes::WIN_HAMMING);
+    rx_fft_c(unsigned int fftsize=4096, double quad_rate=0, int wintype=gr::filter::firdes::WIN_HAMMING);
 
 public:
     ~rx_fft_c();
@@ -83,10 +84,12 @@ public:
     int  get_window_type() const;
 
     void set_fft_size(unsigned int fftsize);
+    void set_quad_rate(double quad_rate);
     unsigned int get_fft_size() const;
 
 private:
     unsigned int d_fftsize;   /*! Current FFT size. */
+    double       d_quadrate;
     int          d_wintype;   /*! Current window type. */
 
     boost::mutex d_mutex;  /*! Used to lock FFT output buffer. */
@@ -95,8 +98,10 @@ private:
     std::vector<float>  d_window; /*! FFT window taps. */
 
     boost::circular_buffer<gr_complex> d_cbuf; /*! buffer to accumulate samples. */
+    std::chrono::time_point<std::chrono::steady_clock> d_lasttime;
 
     void do_fft(const gr_complex *data_in, unsigned int size);
+    void set_params();
 
 };
 
@@ -109,7 +114,7 @@ private:
  * of raw pointers, the rx_fft_f constructor is private.
  * make_rx_fft_f is the public interface for creating new instances.
  */
-rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize=1024, int wintype=gr::filter::firdes::WIN_HAMMING);
+rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize=1024, double audio_rate=48000, int wintype=gr::filter::firdes::WIN_HAMMING);
 
 
 /*! \brief Block for computing real FFT.
@@ -127,10 +132,10 @@ rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize=1024, int wintype=gr::filter::f
  */
 class rx_fft_f : public gr::sync_block
 {
-    friend rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize, int wintype);
+    friend rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize, double audio_rate, int wintype);
 
 protected:
-    rx_fft_f(unsigned int fftsize=1024, int wintype=gr::filter::firdes::WIN_HAMMING);
+    rx_fft_f(unsigned int fftsize=1024, double audio_rate=48000, int wintype=gr::filter::firdes::WIN_HAMMING);
 
 public:
     ~rx_fft_f();
@@ -149,6 +154,7 @@ public:
 
 private:
     unsigned int d_fftsize;   /*! Current FFT size. */
+    double       d_audiorate;
     int          d_wintype;   /*! Current window type. */
 
     boost::mutex d_mutex;  /*! Used to lock FFT output buffer. */
@@ -157,6 +163,7 @@ private:
     std::vector<float>  d_window; /*! FFT window taps. */
 
     boost::circular_buffer<float> d_cbuf; /*! buffer to accumulate samples. */
+    std::chrono::time_point<std::chrono::steady_clock> d_lasttime;
 
     void do_fft(const float *data_in, unsigned int size);
 


### PR DESCRIPTION
This is an attempt at solving #726 and making the higher FFT/waterfall update rates work properly. The main change I've made is to increase the size of the circular buffers used for FFTs. I've increased their sizes to store one second of samples, so that the FFT and waterfall will continue updating even if input samples arrive in bursts up to one second long.

I've changed `get_fft_data` to keep track of how much time has passed since the last invocation and consume a corresponding amount of samples. I added a fudge factor of 1.001 to ensure that samples are consumed slightly faster than they arrive so that the circular buffer does not fill up over time and add unnecessary latency. There's a check to ensure that the circular buffer always finishes with at least enough samples for one FFT.

~Since the audio FFT rate is not adjustable, I changed it from 25 fps to 62.5 fps (16 ms) to match the highest I/Q FFT rate.~