### PR TITLE
Fix various bugs with waterfall time span

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -246,6 +246,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
             uiDockFft, SLOT(setPandapterRange(float,float)));
     connect(ui->plotter, SIGNAL(newZoomLevel(float)),
             uiDockFft, SLOT(setZoomLevel(float)));
+    connect(ui->plotter, SIGNAL(newSize()), this, SLOT(setWfSize()));
 
     connect(uiDockFft, SIGNAL(fftColorChanged(QColor)), this, SLOT(setFftColor(QColor)));
     connect(uiDockFft, SIGNAL(fftFillToggled(bool)), this, SLOT(setFftFill(bool)));
@@ -1608,6 +1609,8 @@ void MainWindow::setIqFftRate(int fps)
 
     if (interval > 9 && iq_fft_timer->isActive())
         iq_fft_timer->setInterval(interval);
+
+    uiDockFft->setWfResolution(ui->plotter->getWfTimeRes());
 }
 
 void MainWindow::setIqFftWindow(int type)
@@ -1620,6 +1623,11 @@ void MainWindow::setWfTimeSpan(quint64 span_ms)
 {
     // set new time span, then send back new resolution to be shown by GUI label
     ui->plotter->setWaterfallSpan(span_ms);
+    uiDockFft->setWfResolution(ui->plotter->getWfTimeRes());
+}
+
+void MainWindow::setWfSize()
+{
     uiDockFft->setWfResolution(ui->plotter->getWfTimeRes());
 }
 

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -189,6 +189,7 @@ private slots:
     void setPeakDetection(bool enabled);
     void setFftPeakHold(bool enable);
     void setWfTimeSpan(quint64 span_ms);
+    void setWfSize();
 
     /* FFT plot */
     void on_plotter_newDemodFreq(qint64 freq, qint64 delta);   /*! New demod freq (aka. filter offset). */

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -32,6 +32,7 @@
 #define DEFAULT_FFT_RATE        25
 #define DEFAULT_FFT_SIZE        8192
 #define DEFAULT_FFT_WINDOW      1       // Hann
+#define DEFAULT_WATERFALL_SPAN  0       // Auto
 #define DEFAULT_FFT_SPLIT       35
 #define DEFAULT_FFT_AVG         75
 #define DEFAULT_COLORMAP        "gqrx"
@@ -215,6 +216,12 @@ void DockFft::saveSettings(QSettings *settings)
     else
         settings->remove("fft_window");
 
+    intval = ui->wfSpanComboBox->currentIndex();
+    if (intval != DEFAULT_WATERFALL_SPAN)
+        settings->setValue("waterfall_span", intval);
+    else
+        settings->remove("waterfall_span");
+
     if (ui->fftAvgSlider->value() != DEFAULT_FFT_AVG)
         settings->setValue("averaging", ui->fftAvgSlider->value());
     else
@@ -300,6 +307,10 @@ void DockFft::readSettings(QSettings *settings)
     intval = settings->value("fft_window", DEFAULT_FFT_WINDOW).toInt(&conv_ok);
     if (conv_ok)
         ui->fftWinComboBox->setCurrentIndex(intval);
+
+    intval = settings->value("waterfall_span", DEFAULT_WATERFALL_SPAN).toInt(&conv_ok);
+    if (conv_ok)
+        ui->wfSpanComboBox->setCurrentIndex(intval);
 
     intval = settings->value("averaging", DEFAULT_FFT_AVG).toInt(&conv_ok);
     if (conv_ok)

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -511,7 +511,9 @@ int CPlotter::getNearestPeak(QPoint pt)
 void CPlotter::setWaterfallSpan(quint64 span_ms)
 {
     wf_span = span_ms;
-    msec_per_wfline = wf_span / m_WaterfallPixmap.height();
+    if (m_WaterfallPixmap.height() > 0) {
+        msec_per_wfline = wf_span / m_WaterfallPixmap.height();
+    }
     clearWaterfall();
 }
 
@@ -599,7 +601,7 @@ quint64 CPlotter::getWfTimeRes(void)
     if (msec_per_wfline)
         return msec_per_wfline;
     else
-        return 1000 * fft_rate / m_WaterfallPixmap.height(); // Auto mode
+        return 1000 / fft_rate; // Auto mode
 }
 
 void CPlotter::setFftRate(int rate_hz)
@@ -869,6 +871,7 @@ void CPlotter::resizeEvent(QResizeEvent* )
     }
 
     drawOverlay();
+    emit newSize();
 }
 
 // Called by QT when screen needs to be redrawn
@@ -1322,7 +1325,7 @@ void CPlotter::drawOverlay()
             int level = 0;
             while(level < nLevels && tagEnd[level] > x)
                 level++;
-            
+
             if(level == nLevels)
                 level = 0;
 

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -128,6 +128,7 @@ signals:
     void newFilterFreq(int low, int high);  /* substitute for NewLow / NewHigh */
     void pandapterRangeChanged(float min, float max);
     void newZoomLevel(float level);
+    void newSize();
 
 public slots:
     // zoom functions


### PR DESCRIPTION
I noticed several issues with the waterfall time span feature:

1. The resolution display shows "Res: - s" when Gqrx starts, instead of the current time resolution.
2. The indicated time resolution is incorrect when the time span is set to Auto.
3. When the time span is set to Auto, the indicated time resolution does not update if the FFT rate is changed.
4. The indicated time resolution does not update when the window is resized.
5. The time span selection is not saved in the settings file.

This pull request should hopefully address all these issues.