### PR TITLE
Misc improvements to the DSP chain

### DIFF
--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -24,17 +24,14 @@
 #define RECEIVER_H
 
 #if GNURADIO_VERSION < 0x030800
-#include <gnuradio/analog/sig_source_c.h>
 #include <gnuradio/blocks/multiply_const_ff.h>
-#include <gnuradio/blocks/multiply_cc.h>
 #else
-#include <gnuradio/analog/sig_source.h>
 #include <gnuradio/blocks/multiply_const.h>
-#include <gnuradio/blocks/multiply.h>
 #endif
 
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/blocks/null_sink.h>
+#include <gnuradio/blocks/rotator_cc.h>
 #include <gnuradio/blocks/wavfile_sink.h>
 #include <gnuradio/blocks/wavfile_source.h>
 #include <gnuradio/top_block.h>
@@ -229,6 +226,7 @@ public:
 
 private:
     void        connect_all(rx_chain type);
+    void        update_ddc();
 
 private:
     bool        d_running;          /*!< Whether receiver is running or not. */
@@ -263,8 +261,7 @@ private:
     rx_fft_c_sptr             iq_fft;     /*!< Baseband FFT block. */
     rx_fft_f_sptr             audio_fft;  /*!< Audio FFT block. */
 
-    gr::analog::sig_source_c::sptr      lo;  /*!< oscillator used for tuning. */
-    gr::blocks::multiply_cc::sptr       mixer;
+    gr::blocks::rotator_cc::sptr rot;     /*!< Rotator used when only shifting frequency */
 
     gr::blocks::multiply_const_ff::sptr audio_gain0; /*!< Audio gain block. */
     gr::blocks::multiply_const_ff::sptr audio_gain1; /*!< Audio gain block. */


### PR DESCRIPTION
Ideally the rotator would be replaced with a freq_xlating_fir filter doing pre-decimation before the actual RX chain, but that's a more intrustive change and the 'rotator' only would still need to be a supported option anyway (for low bandwidth SDRs), so this is a good first step.

When the second step becomes reality, the update_ddc method will be a bit more filled, properly selecting which path to use and reconfiguring the filter decimation and taps.