### PR TITLE
Speed up FFT & waterfall by deferring log calculations

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -110,10 +110,9 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
 
     d_fftData = new std::complex<float>[MAX_FFT_SIZE];
     d_realFftData = new float[MAX_FFT_SIZE];
-    d_pwrFftData = new float[MAX_FFT_SIZE]();
     d_iirFftData = new float[MAX_FFT_SIZE];
     for (int i = 0; i < MAX_FFT_SIZE; i++)
-        d_iirFftData[i] = -140.0;  // dBFS
+        d_iirFftData[i] = 0;
 
     /* timer for data decoders */
     dec_timer = new QTimer(this);
@@ -382,7 +381,6 @@ MainWindow::~MainWindow()
     delete [] d_fftData;
     delete [] d_realFftData;
     delete [] d_iirFftData;
-    delete [] d_pwrFftData;
     delete qsvg_dummy;
 }
 
@@ -1300,7 +1298,7 @@ void MainWindow::iqFftTimeout()
 
         /* calculate power in dBFS */
         pwr = pwr_scale * (pt.imag() * pt.imag() + pt.real() * pt.real());
-        d_realFftData[i] = 10.0 * log10f(pwr + 1.0e-20);
+        d_realFftData[i] = pwr;
 
         /* FFT averaging */
         d_iirFftData[i] += d_fftAvg * (d_realFftData[i] - d_iirFftData[i]);
@@ -1348,7 +1346,7 @@ void MainWindow::audioFftTimeout()
 
         /* calculate power in dBFS */
         pwr = pwr_scale * (pt.imag() * pt.imag() + pt.real() * pt.real());
-        d_realFftData[i] = 10.0 * log10f(pwr + 1.0e-20);
+        d_realFftData[i] = pwr;
     }
 
     uiDockAudio->setNewFftData(d_realFftData, fftsize);
@@ -1599,6 +1597,8 @@ void MainWindow::setIqFftSize(int size)
 {
     qDebug() << "Changing baseband FFT size to" << size;
     rx->set_iq_fft_size(size);
+    for (int i = 0; i < size; i++)
+        d_iirFftData[i] = 0;
 }
 
 /** Baseband FFT rate has changed. */

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -86,7 +86,6 @@ private:
     std::complex<float>* d_fftData;
     float          *d_realFftData;
     float          *d_iirFftData;
-    float          *d_pwrFftData;
     float           d_fftAvg;      /*!< FFT averaging parameter set by user (not the true gain). */
 
     bool d_have_audio;  /*!< Whether we have audio (i.e. not with demod_off. */

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1173,8 +1173,9 @@ void CPlotter::getScreenIntegerFFTData(qint32 plotHeight, qint32 plotWidth,
     if (largeFft)
     {
         // more FFT points than plot points
+        double pixPerBin = (double)plotWidth / (m_BinMax - m_BinMin);
         for (i = minbin; i < maxbin; i++)
-            m_pTranslateTbl[i] = ((qint64)(i-m_BinMin)*plotWidth) / (m_BinMax - m_BinMin);
+            m_pTranslateTbl[i] = pixPerBin * (i-m_BinMin);
         *xmin = m_pTranslateTbl[minbin];
         *xmax = m_pTranslateTbl[maxbin - 1] + 1;
     }


### PR DESCRIPTION
I did some profiling to see what opportunities for optimization there might be. A lot of CPU time is spent in `MainWindow::iqFftTimeout`, especially when using large FFT sizes, so this is a useful function to focus on.

About a third of the CPU time in `MainWindow::iqFftTimeout` is spent in `log10f`, which converts the FFT bin powers to dB. When the FFT is larger than the plot width, only a fraction of these dB values are actually displayed to the user. So we can save a lot of processing time by computing the dB value only for the FFT bins that are displayed. To do this, I've moved the dB calculation to the end of `CPlotter::getScreenIntegerFFTData`.

One side effect of this change is that the FFT averaging is now computed over the FFT bin powers instead of the dB values. This is probably a more sensible way to average anyway.

After making this change, the CPU time spent in `MainWindow::iqFftTimeout` dropped from 71 ms to 47 ms per invocation, when using an FFT size of 1048576.