### PR TITLE
Set RTL-SDR gain to midpoint by default

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -495,7 +495,7 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
         {
             /* rtlsdr gain is 0 by default making users think their device is
              * deaf. Therefore, we don't read gain from the device, but initialize
-             * it to max_gain.
+             * it to the midpoint.
              */
             updateGainStages(false);
         }
@@ -765,7 +765,7 @@ void MainWindow::updateFrequencyRange()
 /**
  * @brief Update gain stages.
  * @param read_from_device If true, the gain value will be read from the device,
- *                         otherwise we set gain = max.
+ *                         otherwise we set gain to the midpoint.
  *
  * This function fetches a list of available gain stages with their range
  * and sends them to the input control UI widget.
@@ -787,7 +787,7 @@ void MainWindow::updateGainStages(bool read_from_device)
         }
         else
         {
-            gain.value = gain.stop;
+            gain.value = (gain.start + gain.stop) / 2;
             rx->set_gain(gain.name, gain.value);
         }
         gain_list.push_back(gain);


### PR DESCRIPTION
When starting up Gqrx with an RTL-SDR for the first time, the gain is set to the maximum. (For the reasoning behind this, see aa4c842af3789f77736302666657088bc2b308c1.) While this is better than starting at zero gain, it is very likely that the user will experience distortion since the ADC will probably be overloaded. To improve the new-user experience, I propose to default to the midpoint instead. For R820T-based dongles this is 24.8 dB.