### PR TITLE
Increase default audio gain to -6 dB

### DIFF
--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -49,6 +49,7 @@
 #include <gnuradio/audio/sink.h>
 #endif
 
+#define DEFAULT_AUDIO_GAIN -6.0
 
 /**
  * @brief Public contructor.
@@ -123,8 +124,9 @@ receiver::receiver(const std::string input_device,
     iq_fft = make_rx_fft_c(8192u, gr::filter::firdes::WIN_HANN);
 
     audio_fft = make_rx_fft_f(8192u, gr::filter::firdes::WIN_HANN);
-    audio_gain0 = gr::blocks::multiply_const_ff::make(0.1);
-    audio_gain1 = gr::blocks::multiply_const_ff::make(0.1);
+    audio_gain0 = gr::blocks::multiply_const_ff::make(0);
+    audio_gain1 = gr::blocks::multiply_const_ff::make(0);
+    set_af_gain(DEFAULT_AUDIO_GAIN);
 
     wav_sink = gr::blocks::wavfile_sink::make(get_null_file().c_str(), 2,
                                               (unsigned int) d_audio_rate,

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -368,7 +368,7 @@ void DockAudio::readSettings(QSettings *settings)
 
     settings->beginGroup("audio");
 
-    ival = settings->value("gain", QVariant(-200)).toInt(&conv_ok);
+    ival = settings->value("gain", QVariant(-60)).toInt(&conv_ok);
     if (conv_ok)
         setAudioGain(ival);
 

--- a/src/qtgui/dockaudio.ui
+++ b/src/qtgui/dockaudio.ui
@@ -119,7 +119,7 @@
          <number>500</number>
         </property>
         <property name="value">
-         <number>-200</number>
+         <number>-60</number>
         </property>
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -135,7 +135,7 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string> -20.0 dB</string>
+         <string>-6.0 dB</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>


### PR DESCRIPTION
Gqrx currently has a default audio gain of -20 dB. I find I almost always have to increase it, since the default produces quieter audio than other applications. To improve the new-user experience, I propose to change the default to -6 dB.