### PR TITLE
Lock panadapter and waterfall together by default

### DIFF
--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -270,9 +270,9 @@ void DockFft::saveSettings(QSettings *settings)
 
     // pandapter and waterfall ranges locked together
     if (ui->lockButton->isChecked())
-        settings->setValue("db_ranges_locked", true);
-    else
         settings->remove("db_ranges_locked");
+    else
+        settings->setValue("db_ranges_locked", false);
 
     if (QString::compare(ui->cmapComboBox->currentData().toString(), DEFAULT_COLORMAP))
         settings->setValue("waterfall_colormap", ui->cmapComboBox->currentData().toString());
@@ -343,7 +343,7 @@ void DockFft::readSettings(QSettings *settings)
     setWaterfallRange(fft_min, fft_max);
     emit waterfallRangeChanged((float) fft_min, (float) fft_max);
 
-    bool_val = settings->value("db_ranges_locked", false).toBool();
+    bool_val = settings->value("db_ranges_locked", true).toBool();
     ui->lockButton->setChecked(bool_val);
 
     QString cmap = settings->value("waterfall_colormap", "gqrx").toString();


### PR DESCRIPTION
in 50f3e4660566288e907b55032bafa8587661711c dB ranges for the panadapter and waterfall were separated. Then in https://github.com/csete/gqrx/pull/416 @alexf91 added a "Lock" button to lock the ranges to each other. Currently the lock is off by default.

I always turn the lock setting on, and I believe defaulting to on would be sensible for new users. Thus I'm proposing to make that the default. I'm open to dissenting opinions on this.