### PR TITLE
Decrease default FFT range to (-120, -20)

### DIFF
--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -27,8 +27,8 @@
 #include "dockfft.h"
 #include "ui_dockfft.h"
 
-#define DEFAULT_FFT_MAX_DB     -0
-#define DEFAULT_FFT_MIN_DB     -135
+#define DEFAULT_FFT_MAX_DB     -20
+#define DEFAULT_FFT_MIN_DB     -120
 #define DEFAULT_FFT_RATE        25
 #define DEFAULT_FFT_SIZE        8192
 #define DEFAULT_FFT_WINDOW      1       // Hann


### PR DESCRIPTION
The default FFT dB range is very large (from -135 to 0), which tends to leave a lot of empty space at the top & bottom of the panadapter. I think it might make sense to narrow this a bit, so I'm proposing -120 to -20. This seems to give reasonable results for an RTL-SDR and a USRP B200:

![Screenshot from 2020-02-02 18-23-19](https://user-images.githubusercontent.com/583749/73617094-35c4ae00-45e9-11ea-956d-7daedb1b8326.png)

![Screenshot from 2020-02-02 18-22-44](https://user-images.githubusercontent.com/583749/73617093-33625400-45e9-11ea-93db-751f84632155.png)

