### PR TITLE
Fix division by zero in overlap calculation

### DIFF
--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -556,12 +556,11 @@ void DockFft::updateInfoLabels(void)
     float   size;
     float   rbw;
     float   ovr;
+    int     rate;
 
     if (m_sample_rate == 0.f)
         return;
 
-    interval_ms = 1000 / fftRate();
-    interval_samples = m_sample_rate * (interval_ms / 1000.0);
     size = fftSize();
 
     rbw = m_sample_rate / size;
@@ -572,9 +571,17 @@ void DockFft::updateInfoLabels(void)
     else
         ui->fftRbwLabel->setText(QString("RBW: %1 MHz").arg(1.e-6 * rbw, 0, 'f', 1));
 
-    if (interval_samples >= size)
+    rate = fftRate();
+    if (rate == 0)
         ovr = 0;
     else
-        ovr = 100 * (1.f - interval_samples / size);
+    {
+        interval_ms = 1000 / rate;
+        interval_samples = m_sample_rate * (interval_ms / 1000.0);
+        if (interval_samples >= size)
+            ovr = 0;
+        else
+            ovr = 100 * (1.f - interval_samples / size);
+    }
     ui->fftOvrLabel->setText(QString("Overlap: %1%").arg(ovr, 0, 'f', 0));
 }


### PR DESCRIPTION
Fixes https://github.com/csete/gqrx/issues/738.

I've changed the code to explicitly check for an FFT rate of zero, and set the overlap to 0% in that case.

@al-sharp