### PR TITLE
Fix FFT split bugs, and display audio FFT by default

### DIFF
--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -93,17 +93,17 @@ void CAudioOptions::setUdpPort(int port)
 
 void CAudioOptions::setFftSplit(int pct_2d)
 {
-    ui->fftSplitSlider->setValue(100 - pct_2d);
+    ui->fftSplitSlider->setValue(pct_2d);
 }
 
 int  CAudioOptions::getFftSplit(void) const
 {
-    return 100 - ui->fftSplitSlider->value();
+    return ui->fftSplitSlider->value();
 }
 
 void CAudioOptions::on_fftSplitSlider_valueChanged(int value)
 {
-    emit newFftSplit(100 - value);
+    emit newFftSplit(value);
 }
 
 void CAudioOptions::setPandapterRange(int min, int max)
@@ -183,4 +183,3 @@ void CAudioOptions::on_udpPort_valueChanged(int port)
 {
     emit newUdpPort(port);
 }
-

--- a/src/qtgui/audio_options.ui
+++ b/src/qtgui/audio_options.ui
@@ -48,8 +48,14 @@
            <property name="toolTip">
             <string>Adjust split between pandapter and waterfall</string>
            </property>
+           <property name="minimum">
+            <number>0</number>
+           </property>
            <property name="maximum">
             <number>100</number>
+           </property>
+           <property name="value">
+            <number>65</number>
            </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -27,6 +27,8 @@
 #include "dockaudio.h"
 #include "ui_dockaudio.h"
 
+#define DEFAULT_FFT_SPLIT 65
+
 DockAudio::DockAudio(QWidget *parent) :
     QDockWidget(parent),
     ui(new Ui::DockAudio),
@@ -65,7 +67,7 @@ DockAudio::DockAudio(QWidget *parent) :
     ui->audioSpectrum->setSampleRate(48000);  // Full bandwidth
     ui->audioSpectrum->setSpanFreq(12000);
     ui->audioSpectrum->setCenterFreq(0);
-    ui->audioSpectrum->setPercent2DScreen(100);
+    ui->audioSpectrum->setPercent2DScreen(DEFAULT_FFT_SPLIT);
     ui->audioSpectrum->setFftCenterFreq(6000);
     ui->audioSpectrum->setDemodCenterFreq(0);
     ui->audioSpectrum->setFilterBoxEnabled(false);
@@ -315,7 +317,7 @@ void DockAudio::saveSettings(QSettings *settings)
     settings->setValue("gain", audioGain());
 
     ival = audioOptions->getFftSplit();
-    if (ival >= 0 && ival < 100)
+    if (ival != DEFAULT_FFT_SPLIT)
         settings->setValue("fft_split", ival);
     else
         settings->remove("fft_split");
@@ -372,7 +374,7 @@ void DockAudio::readSettings(QSettings *settings)
     if (conv_ok)
         setAudioGain(ival);
 
-    ival = settings->value("fft_split", QVariant(100)).toInt(&conv_ok);
+    ival = settings->value("fft_split", DEFAULT_FFT_SPLIT).toInt(&conv_ok);
     if (conv_ok)
         audioOptions->setFftSplit(ival);
 

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -497,7 +497,7 @@
              <number>100</number>
             </property>
             <property name="value">
-             <number>50</number>
+             <number>35</number>
             </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -165,7 +165,7 @@ CPlotter::CPlotter(QWidget *parent) : QFrame(parent)
     m_WaterfallPixmap = QPixmap(0,0);
     m_Size = QSize(0,0);
     m_GrabPosition = 0;
-    m_Percent2DScreen = 30;	//percent of screen used for 2D display
+    m_Percent2DScreen = 35;	//percent of screen used for 2D display
     m_VdivDelta = 30;
     m_HdivDelta = 70;
 


### PR DESCRIPTION
While investigating @devnulling's proposal to display the audio FFT by default in https://github.com/csete/gqrx/issues/741, I noticed a couple bugs in the FFT split functionality:

* The I/Q FFT split slider defaults to 50, while the default in dockfft.cpp is 35 and the default in plotter.cpp is 30. As a result, the split will be set to 30 if the value saved in the configuration file happens to be 50. I've corrected this by setting all three values to 35.
* The audio FFT slider and the I/Q FFT slider work in opposite directions. I've changed the direction of the audio FFT slider to match the I/Q FFT slider.

I also implemented the suggestion to display the audio FFT by default, and set the default to 65. If you don't like that change, we could make the default 100. I happen to like 65 though.