### PR TITLE
Fix crash when switching device to USRP

### DIFF
--- a/src/qtgui/dockinputctl.cpp
+++ b/src/qtgui/dockinputctl.cpp
@@ -96,8 +96,8 @@ void DockInputCtl::readSettings(QSettings * settings)
 
             gain_name = gain_iter.key();
             gain_value = 0.1 * (double)(gain_iter.value().toInt());
-            setGain(gain_name, gain_value);
-            emit gainChanged(gain_name, gain_value);
+            if (setGain(gain_name, gain_value))
+                emit gainChanged(gain_name, gain_value);
         }
     }
 
@@ -200,9 +200,10 @@ double DockInputCtl::lnbLo()
  * @param name The name of the gain to change.
  * @param value The new value.
  */
-void DockInputCtl::setGain(QString name, double value)
+bool DockInputCtl::setGain(QString name, double value)
 {
     int gain = -1;
+    bool success = false;
 
     for (int idx = 0; idx < gain_labels.length(); idx++)
     {
@@ -210,9 +211,12 @@ void DockInputCtl::setGain(QString name, double value)
         {
             gain = (int)(10 * value);
             gain_sliders.at(idx)->setValue(gain);
+            success = true;
             break;
         }
     }
+
+    return success;
 }
 
 /**

--- a/src/qtgui/dockinputctl.h
+++ b/src/qtgui/dockinputctl.h
@@ -102,7 +102,7 @@ public:
     void    setFreqCtrlReset(bool enabled);
 
 public slots:
-    void    setGain(QString name, double value);
+    bool    setGain(QString name, double value);
 
 signals:
     void gainChanged(QString name, double value);


### PR DESCRIPTION
Fixes #125.

When switching from an RTL-SDR to a USRP B200 in the device chooser, Gqrx crashes with the following error:

> set_rx_gain: gain "LNA" not found for channel 0. Available gains: PGA

This occurs because the RTL-SDR's LNA gain value is loaded from the settings file and then set, even though the USRP does not have an LNA gain. When asked to set a non-existent gain, UHD throws an exception.

To solve the problem, I modified `DockInputCtl::readSettings` to check the existence of a gain before attempting to set it. Since `MainWindow::loadSettings` updates the gain stages prior to calling `DockInputCtl::readSettings`, `DockInputCtl` is able to check which gains are valid for the current device.