### PR TITLE
Use /dev/urandom to avoid blocking

### DIFF
--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -32,7 +32,7 @@ std::string receiver::get_random_file(void)
     static std::string path;
     if (path.empty())
     {
-        path = "/dev/random";
+        path = "/dev/urandom";
         QFileInfo checkFile(QString::fromStdString(path));
         if (!checkFile.exists())
         {


### PR DESCRIPTION
Gqrx uses a random file as a dummy input in certain circumstances:

https://github.com/csete/gqrx/blob/490ee3be4f1c5e0319b7610912104e2d0a47fd4e/src/applications/gqrx/receiver.cpp#L80-L83

Currently `get_random_file` returns `/dev/random` if it exists. That's problematic on Linux, because `/dev/random` consumes bytes directly from the entropy pool and blocks once it's empty. This device can typically provide only a few bytes per second. As a result, Gqrx becomes unresponsive if the random input is ever used. (I hit this case a few times while testing other changes.)

To solve the problem, I propose to replace `/dev/random` with `/dev/urandom`, which is guaranteed not to block since it uses a pseudorandom number generator.