### PR TITLE
Explicitly set antenna in readSettings

### DIFF
--- a/src/qtgui/dockinputctl.cpp
+++ b/src/qtgui/dockinputctl.cpp
@@ -77,6 +77,7 @@ void DockInputCtl::readSettings(QSettings * settings)
     {
         QString ant = settings->value("input/antenna", "").toString();
         setAntenna(ant);
+        emit antennaSelected(ant);
     }
 
     // gains are stored as a QMap<QString, QVariant(int)>


### PR DESCRIPTION
When using a device with multiple antenna inputs (e.g. USRP B200), Gqrx forgets to set the antenna input when switching from I/Q playback back to hardware input. To fix this, I've added an `emit`, like all the other settings already have.