### PR TITLE
Simplify I/Q and WAV recording code

### DIFF
--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -49,26 +49,3 @@ std::string receiver::get_random_file(void)
     }
     return path;
 }
-
-std::string receiver::get_null_file(void)
-{
-    static std::string path;
-    if (path.empty())
-    {
-        path = "/dev/null";
-        QFileInfo checkFile(QString::fromStdString(path));
-        if (!checkFile.exists())
-        {
-            //static temp file persists until process end
-            static QTemporaryFile temp_file;
-            temp_file.open();
-            path = temp_file.fileName().toStdString();
-            {
-                QDataStream stream(&temp_file);
-                for (size_t i = 0; i < 1024*8; i++) stream << qint8(0);
-            }
-            std::cout << "Created null file " << path << std::endl;
-        }
-    }
-    return path;
-}

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -109,12 +109,6 @@ receiver::receiver(const std::string input_device,
         d_quad_rate = d_input_rate;
     }
 
-
-    // create I/Q sink and close it
-    iq_sink = gr::blocks::file_sink::make(sizeof(gr_complex), get_null_file().c_str(), true);
-    iq_sink->set_unbuffered(true);
-    iq_sink->close();
-
     rx  = make_nbrx(d_quad_rate, d_audio_rate);
     rot = gr::blocks::rotator_cc::make(0.0);
 
@@ -125,10 +119,6 @@ receiver::receiver(const std::string input_device,
     audio_fft = make_rx_fft_f(8192u, gr::filter::firdes::WIN_HANN);
     audio_gain0 = gr::blocks::multiply_const_ff::make(0.1);
     audio_gain1 = gr::blocks::multiply_const_ff::make(0.1);
-
-    wav_sink = gr::blocks::wavfile_sink::make(get_null_file().c_str(), 2,
-                                              (unsigned int) d_audio_rate,
-                                              16);
 
     audio_udp_sink = make_udp_sink_f();
 
@@ -975,19 +965,18 @@ receiver::status receiver::start_audio_recording(const std::string filename)
         return STATUS_ERROR;
     }
 
-    // not strictly necessary to lock but I think it is safer
-    tb->lock();
-
     // if this fails, we don't want to go and crash now, do we
     try {
-        wav_sink->open(filename.c_str());
-        wav_sink->set_sample_rate((unsigned int) d_audio_rate);
+        wav_sink = gr::blocks::wavfile_sink::make(filename.c_str(), 2,
+                                                  (unsigned int) d_audio_rate,
+                                                  16);
     }
     catch (std::runtime_error &e) {
         std::cout << "Error opening " << filename << ": " << e.what() << std::endl;
         return STATUS_ERROR;
     }
 
+    tb->lock();
     tb->connect(rx, 0, wav_sink, 0);
     tb->connect(rx, 1, wav_sink, 1);
     tb->unlock();
@@ -1021,6 +1010,7 @@ receiver::status receiver::stop_audio_recording()
     tb->disconnect(rx, 0, wav_sink, 0);
     tb->disconnect(rx, 1, wav_sink, 1);
     tb->unlock();
+    wav_sink.reset();
     d_recording_wav = false;
 
     std::cout << "Audio recorder stopped" << std::endl;
@@ -1136,28 +1126,23 @@ receiver::status receiver::start_iq_recording(const std::string filename)
         return STATUS_ERROR;
     }
 
-    // iq_sink was created in the constructor
-    if (iq_sink) {
-        tb->lock();
-        if (!iq_sink->open(filename.c_str()))
-        {
-            status = STATUS_ERROR;
-        }
-        else
-        {
-            if (d_decim >= 2)
-                tb->connect(input_decim, 0, iq_sink, 0);
-            else
-                tb->connect(src, 0, iq_sink, 0);
-
-            d_recording_iq = true;
-        }
-        tb->unlock();
+    try
+    {
+        iq_sink = gr::blocks::file_sink::make(sizeof(gr_complex), filename.c_str(), true);
     }
-    else {
-        std::cout << __func__ << ": I/Q file sink does not exist" << std::endl;
+    catch (std::runtime_error &e)
+    {
+        std::cout << __func__ << ": couldn't open I/Q file" << std::endl;
         return STATUS_ERROR;
     }
+
+    tb->lock();
+    if (d_decim >= 2)
+        tb->connect(input_decim, 0, iq_sink, 0);
+    else
+        tb->connect(src, 0, iq_sink, 0);
+    d_recording_iq = true;
+    tb->unlock();
 
     return status;
 }
@@ -1179,6 +1164,7 @@ receiver::status receiver::stop_iq_recording()
         tb->disconnect(src, 0, iq_sink, 0);
 
     tb->unlock();
+    iq_sink.reset();
     d_recording_iq = false;
 
     return STATUS_OK;

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -287,9 +287,6 @@ private:
 
     //! Get a path to a file containing random bytes
     static std::string get_random_file(void);
-
-    //! Get a path to a file containing all-zero bytes
-    static std::string get_null_file(void);
 };
 
 #endif // RECEIVER_H


### PR DESCRIPTION
It's simpler to create I/Q and WAV file sinks at the time they're needed, rather than building them in the receiver's constructor and setting their outputs to /dev/null. This eliminates the need for `receiver::get_null_file`.

I verified that I/Q and WAV recording still work, and also tested the error handling by replacing the filenames with `""` in the code temporarily. All appears to work as intended.