### PR TITLE
Handle the error when set_input_device fails

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -472,8 +472,20 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
     QString indev = m_settings->value("input/device", "").toString();
     if (!indev.isEmpty())
     {
-        conf_ok = true;
-        rx->set_input_device(indev.toStdString());
+        try
+        {
+            rx->set_input_device(indev.toStdString());
+            conf_ok = true;
+        }
+        catch (std::runtime_error &x)
+        {
+            QMessageBox::warning(nullptr,
+                             QObject::tr("Failed to set input device"),
+                             QObject::tr("<p><b>%1</b></p>"
+                                         "Please select another device.")
+                                     .arg(x.what()),
+                             QMessageBox::Ok);
+        }
 
         // Update window title
         QRegExp regexp("'([a-zA-Z0-9 \\-\\_\\/\\.\\,\\(\\)]+)'");

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -194,6 +194,8 @@ void receiver::stop()
  */
 void receiver::set_input_device(const std::string device)
 {
+    std::string error = "";
+
     if (device.empty())
         return;
 
@@ -227,7 +229,17 @@ void receiver::set_input_device(const std::string device)
     }
 
     src.reset();
-    src = osmosdr::source::make(device);
+
+    try
+    {
+        src = osmosdr::source::make(device);
+    }
+    catch (std::runtime_error &x)
+    {
+        error = x.what();
+        src = osmosdr::source::make("file="+get_random_file()+",freq=428e6,rate=96000,repeat=true,throttle=true");
+    }
+
     if(src->get_sample_rate() != 0)
         set_input_rate(src->get_sample_rate());
 
@@ -243,6 +255,11 @@ void receiver::set_input_device(const std::string device)
 
     if (d_running)
         tb->start();
+
+    if (error != "")
+    {
+        throw std::runtime_error(error);
+    }
 }
 
 


### PR DESCRIPTION
If the configured input device is not plugged in when launching Gqrx, the program simply crashes. By catching the exception in `receiver::set_input_device` we can handle the situation gracefully and give the user an opportunity to select another device without having to launch Gqrx for a second time.