### PR TITLE
Implement DDC using a frequency xlating FIR filter

### DIFF
--- a/gqrx.pro
+++ b/gqrx.pro
@@ -103,6 +103,7 @@ SOURCES += \
     src/dsp/agc_impl.cpp \
     src/dsp/correct_iq_cc.cpp \
     src/dsp/filter/fir_decim.cpp \
+    src/dsp/downconverter.cpp \
     src/dsp/fm_deemph.cpp \
     src/dsp/lpf.cpp \
     src/dsp/rds/decoder_impl.cc \
@@ -157,6 +158,7 @@ HEADERS += \
     src/dsp/correct_iq_cc.h \
     src/dsp/filter/fir_decim.h \
     src/dsp/filter/fir_decim_coef.h \
+    src/dsp/downconverter.h \
     src/dsp/fm_deemph.h \
     src/dsp/lpf.h \
     src/dsp/rds/api.h \

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -31,7 +31,6 @@
 
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/blocks/null_sink.h>
-#include <gnuradio/blocks/rotator_cc.h>
 #include <gnuradio/blocks/wavfile_sink.h>
 #include <gnuradio/blocks/wavfile_source.h>
 #include <gnuradio/top_block.h>
@@ -39,6 +38,7 @@
 #include <string>
 
 #include "dsp/correct_iq_cc.h"
+#include "dsp/downconverter.h"
 #include "dsp/filter/fir_decim.h"
 #include "dsp/rx_noise_blanker_cc.h"
 #include "dsp/rx_filter.h"
@@ -226,14 +226,15 @@ public:
 
 private:
     void        connect_all(rx_chain type);
-    void        update_ddc();
 
 private:
     bool        d_running;          /*!< Whether receiver is running or not. */
     double      d_input_rate;       /*!< Input sample rate. */
-    double      d_quad_rate;        /*!< Quadrature rate (input_rate / decim) */
+    double      d_decim_rate;       /*!< Rate after decimation (input_rate / decim) */
+    double      d_quad_rate;        /*!< Quadrature rate (after down-conversion) */
     double      d_audio_rate;       /*!< Audio output rate. */
     unsigned int    d_decim;        /*!< input decimation. */
+    unsigned int    d_ddc_decim;    /*!< Down-conversion decimation. */
     double      d_rf_freq;          /*!< Current RF frequency. */
     double      d_filter_offset;    /*!< Current filter offset */
     double      d_cw_offset;        /*!< CW offset */
@@ -261,7 +262,7 @@ private:
     rx_fft_c_sptr             iq_fft;     /*!< Baseband FFT block. */
     rx_fft_f_sptr             audio_fft;  /*!< Audio FFT block. */
 
-    gr::blocks::rotator_cc::sptr rot;     /*!< Rotator used when only shifting frequency */
+    downconverter_cc_sptr     ddc;        /*!< Digital down-converter for demod chain. */
 
     gr::blocks::multiply_const_ff::sptr audio_gain0; /*!< Audio gain block. */
     gr::blocks::multiply_const_ff::sptr audio_gain1; /*!< Audio gain block. */

--- a/src/dsp/CMakeLists.txt
+++ b/src/dsp/CMakeLists.txt
@@ -22,6 +22,8 @@ add_source_files(SRCS_LIST
 	agc_impl.h
 	correct_iq_cc.cpp
 	correct_iq_cc.h
+	downconverter.cpp
+	downconverter.h
 	fm_deemph.cpp
 	fm_deemph.h
 	lpf.cpp

--- a/src/dsp/downconverter.cpp
+++ b/src/dsp/downconverter.cpp
@@ -1,0 +1,106 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Clayton Smith VE3IRR.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#include <math.h>
+#include <gnuradio/filter/firdes.h>
+#include <gnuradio/io_signature.h>
+
+#include "downconverter.h"
+
+#define LPF_CUTOFF 120e3
+
+downconverter_cc_sptr make_downconverter_cc(unsigned int decim, double center_freq, double samp_rate)
+{
+    return gnuradio::get_initial_sptr(new downconverter_cc(decim, center_freq, samp_rate));
+}
+
+downconverter_cc::downconverter_cc(unsigned int decim, double center_freq, double samp_rate)
+    : gr::hier_block2("downconverter_cc",
+          gr::io_signature::make(1, 1, sizeof(gr_complex)),
+          gr::io_signature::make(1, 1, sizeof(gr_complex))),
+      d_decim(decim),
+      d_center_freq(center_freq),
+      d_samp_rate(samp_rate)
+{
+    connect_all();
+    update_proto_taps();
+    update_phase_inc();
+}
+
+downconverter_cc::~downconverter_cc()
+{
+
+}
+
+void downconverter_cc::set_decim_and_samp_rate(unsigned int decim, double samp_rate)
+{
+    d_samp_rate = samp_rate;
+    if (decim != d_decim)
+    {
+        d_decim = decim;
+        lock();
+        disconnect_all();
+        connect_all();
+        unlock();
+    }
+    update_proto_taps();
+    update_phase_inc();
+}
+
+void downconverter_cc::set_center_freq(double center_freq)
+{
+    d_center_freq = center_freq;
+    update_phase_inc();
+}
+
+void downconverter_cc::connect_all()
+{
+    if (d_decim > 1)
+    {
+        filt = gr::filter::freq_xlating_fir_filter_ccf::make(d_decim, {1}, 0.0, d_samp_rate);
+        connect(self(), 0, filt, 0);
+        connect(filt, 0, self(), 0);
+    }
+    else
+    {
+        rot = gr::blocks::rotator_cc::make(0.0);
+        connect(self(), 0, rot, 0);
+        connect(rot, 0, self(), 0);
+    }
+}
+
+void downconverter_cc::update_proto_taps()
+{
+    if (d_decim > 1)
+    {
+        double out_rate = d_samp_rate / d_decim;
+        filt->set_taps(gr::filter::firdes::low_pass(1.0, d_samp_rate, LPF_CUTOFF, out_rate - 2*LPF_CUTOFF));
+    }
+}
+
+void downconverter_cc::update_phase_inc()
+{
+    if (d_decim > 1)
+        filt->set_center_freq(d_center_freq);
+    else
+        rot->set_phase_inc(-2.0 * M_PI * d_center_freq / d_samp_rate);
+}

--- a/src/dsp/downconverter.h
+++ b/src/dsp/downconverter.h
@@ -1,0 +1,61 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Clayton Smith VE3IRR.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#pragma once
+
+#if GNURADIO_VERSION < 0x030800
+#include <gnuradio/filter/freq_xlating_fir_filter_ccf.h>
+#else
+#include <gnuradio/filter/freq_xlating_fir_filter.h>
+#endif
+
+#include <gnuradio/blocks/rotator_cc.h>
+#include <gnuradio/hier_block2.h>
+
+class downconverter_cc;
+
+typedef boost::shared_ptr<downconverter_cc> downconverter_cc_sptr;
+downconverter_cc_sptr make_downconverter_cc(unsigned int decim, double center_freq, double samp_rate);
+
+class downconverter_cc : public gr::hier_block2
+{
+    friend downconverter_cc_sptr make_downconverter_cc(unsigned int decim, double center_freq, double samp_rate);
+
+public:
+    downconverter_cc(unsigned int decim, double center_freq, double samp_rate);
+    ~downconverter_cc();
+    void set_decim_and_samp_rate(unsigned int decim, double samp_rate);
+    void set_center_freq(double center_freq);
+
+private:
+    unsigned int d_decim;
+    double d_center_freq;
+    double d_samp_rate;
+    std::vector<float> d_proto_taps;
+
+    void connect_all();
+    void update_proto_taps();
+    void update_phase_inc();
+
+    gr::filter::freq_xlating_fir_filter_ccf::sptr filt;
+    gr::blocks::rotator_cc::sptr rot;
+};


### PR DESCRIPTION
This is a follow-up to @smunaut's [suggestion to implement a DDC block](https://github.com/csete/gqrx/pull/732#issuecomment-581122507). Here I've implemented it using an FFT filter followed by a rotator, like GNU Radio's [Frequency Xlating FFT Filter block](https://github.com/gnuradio/gnuradio/blob/master/gr-filter/python/filter/freq_xlating_fft_filter.py).

The receiver requests a decimation rate that will keep the DDC's output above 1 Msps. Since the demodulators need at most 240 ksps, this leaves plenty of room for filter roll-off so that the number of taps in the FFT filter can be kept low.

if the requested decimation is 1, then the FFT filter is left out of the chain.

Prior to this change, I could use my BladeRF up to 20 Msps before overruns started to occur. After the change, I got up to 34 Msps.

@smunaut's suggestion of multiple decimation stages could improve performance further, but I thought I'd start with a simple design for now.