### PR TITLE
Close 'temp_file' before use.

### DIFF
--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -44,7 +44,8 @@ std::string receiver::get_random_file(void)
                 QDataStream stream(&temp_file);
                 for (size_t i = 0; i < 1024*8; i++) stream << qint8(rand());
             }
-            std::cout << "Created random file " << path << std::endl;
+            temp_file.close();
+            std::cout << "Created random file " << path << std::endl;            
         }
     }
     return path;

--- a/src/applications/gqrx/file_resources.cpp
+++ b/src/applications/gqrx/file_resources.cpp
@@ -45,7 +45,7 @@ std::string receiver::get_random_file(void)
                 for (size_t i = 0; i < 1024*8; i++) stream << qint8(rand());
             }
             temp_file.close();
-            std::cout << "Created random file " << path << std::endl;            
+            std::cout << "Created random file " << path << std::endl;
         }
     }
     return path;


### PR DESCRIPTION
Building on Windows, I got this message from gr-osmosdr:
`gr::log :WARN: file_source0 - file is too small`

I figured the problem was in `src/applications/gqrx/file_resources.cpp`;
The `temp_file` should be closed before trying to use it. Otherwise it stays at 0 bytes.
Hence the warning (and a thrown exception somewhere).