### PR TITLE
usb_claim_interface error because osmosdr devices are not closed

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -293,10 +293,6 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     ui->plotter->setTooltipsEnabled(true);
 #endif
 
-    // Create list of input devices. This must be done before the configuration is
-    // restored because device probing might change the device configuration
-    CIoConfig::getDeviceList(devList);
-
     // restore last session
     if (!loadConfig(cfgfile, true, true))
     {
@@ -472,8 +468,8 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
     QString indev = m_settings->value("input/device", "").toString();
     if (!indev.isEmpty())
     {
-        conf_ok = true;
         rx->set_input_device(indev.toStdString());
+        conf_ok = true;
 
         // Update window title
         QRegExp regexp("'([a-zA-Z0-9 \\-\\_\\/\\.\\,\\(\\)]+)'");
@@ -519,7 +515,7 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
                     new QMessageBox(QMessageBox::Warning, tr("Device Error"),
                                     tr("There was an error configuring the input device.\n"
                                        "Please make sure that a supported device is atached "
-                                       "to the computer and restart gqrx."),
+                                       "to the computer and reconfigure this device."),
                                     QMessageBox::Ok);
             dialog->setModal(true);
             dialog->setAttribute(Qt::WA_DeleteOnClose);
@@ -1772,6 +1768,10 @@ int MainWindow::on_actionIoConfig_triggered()
 {
     qDebug() << "Configure I/O devices.";
 
+    // Create list of input devices. 
+    // This must be done before config dialog class creation.
+    CIoConfig::getDeviceList(devList);
+
     CIoConfig *ioconf = new CIoConfig(m_settings, devList);
     int confres = ioconf->exec();
 
@@ -1801,6 +1801,10 @@ int MainWindow::on_actionIoConfig_triggered()
 int MainWindow::firstTimeConfig()
 {
     qDebug() << __func__;
+
+    // Create list of input devices. 
+    // This must be done before config dialog class creation.
+    CIoConfig::getDeviceList(devList);
 
     CIoConfig *ioconf = new CIoConfig(m_settings, devList);
     int confres = ioconf->exec();

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -23,6 +23,9 @@
 #ifndef RECEIVER_H
 #define RECEIVER_H
 
+#include <string>
+#include <vector>
+
 #if GNURADIO_VERSION < 0x030800
 #include <gnuradio/blocks/multiply_const_ff.h>
 #else
@@ -36,7 +39,6 @@
 #include <gnuradio/blocks/wavfile_source.h>
 #include <gnuradio/top_block.h>
 #include <osmosdr/source.h>
-#include <string>
 
 #include "dsp/correct_iq_cc.h"
 #include "dsp/filter/fir_decim.h"
@@ -251,7 +253,8 @@ private:
 
     gr::top_block_sptr         tb;        /*!< The GNU Radio top block. */
 
-    osmosdr::source::sptr     src;       /*!< Real time I/Q source. */
+    std::vector<osmosdr::source::sptr> src_vec; /*!< Real time I/Q source. */
+
     fir_decim_cc_sptr         input_decim;      /*!< Input decimator. */
     receiver_base_cf_sptr     rx;        /*!< receiver. */
 

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -253,6 +253,11 @@ void CIoConfig::getDeviceList(std::map<QString, QVariant> &devList)
 
         devstr = QString(dev.to_string().c_str());
         devList.insert(std::pair<QString, QVariant>(devlabel, devstr));
+        if (devstr.contains("rtl="))
+        {
+            // provide device with direct sampling set to 2
+            devList.insert(std::pair<QString, QVariant>(devlabel + " DS2", devstr + ",direct_samp=2"));
+        }
         qDebug() << "  " << devlabel;
     }
 }


### PR DESCRIPTION
usb_claim_interface error because osmosdr devices are not closed

And stopping crashing when usb device is not connected or configuration error.

I've also added a device entry for rtlsdr with **direct sampling** set to value 2 (some devices need this for HF).