### PR TITLE
Clear averaged FFT data when changing FFT size

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -10,6 +10,7 @@
      FIXED: Crash when launching without device connected.
      FIXED: Crash when setting invalid RF gains.
      FIXED: Audio panadapter / waterfall slider direction.
+     FIXED: Clear FFT averages when changing FFT size.
   IMPROVED: DSP performance.
   IMPROVED: Panadapter & waterfall performance.
   IMPROVED: Smooth panadapter & waterfall redrawing.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1597,6 +1597,8 @@ void MainWindow::setIqFftSize(int size)
 {
     qDebug() << "Changing baseband FFT size to" << size;
     rx->set_iq_fft_size(size);
+    for (int i = 0; i < size; i++)
+        d_iirFftData[i] = -140.0;  // dBFS
 }
 
 /** Baseband FFT rate has changed. */


### PR DESCRIPTION
This was originally part of #734.

When changing the FFT size, averaged FFT data is not cleared. This causes incorrect data to be displayed in the panadapter until the old data fades away:

![fft-average](https://user-images.githubusercontent.com/583749/75095270-12927c00-5561-11ea-8a2b-f192990573fb.png)

To fix this I've updated `setIqFftSize` to clear `d_iirFftData`. The -140.0 comes from here:

https://github.com/csete/gqrx/blob/1f85ca2a3827df793005e92180456abc630c97af/src/applications/gqrx/mainwindow.cpp#L114-L115