### PR TITLE
Use Ubuntu 16.04 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 
-dist: trusty
+dist: xenial
 
 language: cpp
 
@@ -14,10 +14,6 @@ env:
   - AUDIO_BACKEND="Gr-audio"
 
 before_install:
-  - sudo add-apt-repository -y ppa:bladerf/bladerf
-  - sudo add-apt-repository -y ppa:ettusresearch/uhd
-  - sudo add-apt-repository -y ppa:myriadrf/drivers
-  - sudo add-apt-repository -y ppa:myriadrf/gnuradio
   - sudo apt-get update -qq
   - sudo apt-get install -y cmake qt5-default libqt5svg5-dev libboost-dev libpulse-dev portaudio19-dev liblog4cpp5-dev gnuradio-dev gr-osmosdr gr-fcdproplus
 


### PR DESCRIPTION
Currently Travis CI is performed on Ubuntu 14.04, which is rather outdated. It's also simpler to build with Ubuntu ~18.04~ **16.04**, since it has all the necessary dependencies in its package archive.

The clang builds [currently fail](https://travis-ci.org/argilo/gqrx/builds/654392032) due to the very slow compilation of parser_impl.cc, but that will be fixed by https://github.com/csete/gqrx/pull/762.