### PR TITLE
Added Band Plan to bottom of FFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The following people and organisations have contributed to gqrx:
 * Christian Lindner, DL2VCL
 * charlylima
 * Clayton Smith, VE3IRR
+* Dallas Epperson
 * Darin Franklin
 * Stefano Leucci
 * Daniil Cherednik

--- a/gqrx.pro
+++ b/gqrx.pro
@@ -124,6 +124,7 @@ SOURCES += \
     src/qtgui/afsk1200win.cpp \
     src/qtgui/agc_options.cpp \
     src/qtgui/audio_options.cpp \
+    src/qtgui/bandplan.cpp \
     src/qtgui/bookmarks.cpp \
     src/qtgui/bookmarkstablemodel.cpp \
     src/qtgui/bookmarkstaglist.cpp \
@@ -185,6 +186,7 @@ HEADERS += \
     src/qtgui/afsk1200win.h \
     src/qtgui/agc_options.h \
     src/qtgui/audio_options.h \
+    src/qtgui/bandplan.h \
     src/qtgui/bookmarks.h \
     src/qtgui/bookmarkstablemodel.h \
     src/qtgui/bookmarkstaglist.h \

--- a/resources/bandplan.csv
+++ b/resources/bandplan.csv
@@ -1,0 +1,114 @@
+# minFrequency, maxFrequency, mode, step, color, name
+
+# USA Amateur Radio
+135700,       137800,       CW,  10, #90009470, 2200m Ham Band
+472000,       479000,       CW,  10, #90009470, 630m Ham Band
+1800000,      2000000,      CW,  10, #90009470, 160m Ham Band
+3500000,      3600000,      CW,  10, #90009470, 80m CW/Data Ham Band
+3600000,      4000000,      CW,  10, #90009470, 80m Phone Ham Band
+5351500,      5366500,      USB, 10, #90009470, 60m Ham Band
+7000000,      7125000,      CW,  10, #90009470, 40m CW/Data Ham Band
+7125000,      7300000,      LSB, 10, #90009470, 40m Phone Ham Band
+10100000,     10150000,     CW,  10, #90009470, 30m CW/Data Ham Band
+14000000,     14150000,     CW,  10, #90009470, 20m CW/Data Ham Band
+14150000,     14350000,     USB, 10, #90009470, 20m Phone Ham Band
+18068000,     18110000,     CW,  10, #90009470, 17m CW/Data Ham Band
+18110000,     18168000,     USB, 10, #90009470, 17m Ham Band
+21000000,     21200000,     CW,  10, #90009470, 15m CW/Data Ham Band
+21200000,     21450000,     USB, 10, #90009470, 15m Ham Band
+24890000,     24930000,     CW,  10, #90009470, 12m CW/Data Ham Band
+24930000,     24990000,     USB, 10, #90009470, 12m Ham Band
+28000000,     28300000,     CW,  10, #90009470, 10m CW/Data Ham Band
+28300000,     29700000,     USB, 10, #90009470, 10m Ham Band
+50000000,     50100000,     CW,  10, #90009470, 6m CW/Data Ham Band
+50100000,     54000000,     USB, 10, #90009470, 6m Ham Band
+144000000,    144100000,    CW,  10, #90009470, 2m CW/Data Ham Band
+144100000,    148000000,    NFM, 10, #90009470, 2m Ham Band
+222000000,    225000000,    NFM, 10, #90009470, 1.25m Ham Band
+420000000,    450000000,    NFM, 10, #90009470, 70cm Ham Band
+902000000,    928000000,    NFM, 10, #90009470, 33cm Ham Band
+1240000000,   1300000000,   NFM, 10, #90009470, 22cm Ham Band
+2300000000,   2310000000,   NFM, 10, #90009470, GHz Ham Band
+2390000000,   2450000000,   NFM, 10, #90009470, GHz Ham Band
+3300000000,   3500000000,   NFM, 10, #90009470, GHz Ham Band
+5650000000,   5925000000,   NFM, 10, #90009470, GHz Ham Band
+10000000000,  10500000000,  NFM, 10, #90009470, GHz Ham Band
+24000000000,  24250000000,  NFM, 10, #90009470, GHz Ham Band
+47000000000,  47200000000,  NFM, 10, #90009470, GHz Ham Band
+77000000000,  81000000000,  NFM, 10, #90009470, GHz Ham Band
+122250000000, 123000000000, NFM, 10, #90009470, GHz Ham Band
+134000000000, 141000000000, NFM, 10, #90009470, GHz Ham Band
+241000000000, 250000000000, NFM, 10, #90009470, GHz Ham Band
+
+# Radionavigation - Source: https://www.ntia.doc.gov/files/ntia/publications/2003-allochrt.pdf
+9000,         14000,        USB, 10, #99AABD26, Radionavigation
+90000,        110000,       USB, 10, #99AABD26, Radionavigation
+190000,       200000,       USB, 10, #99C05017, Aeronautical Radionavigation
+200000,       275000,       USB, 10, #99C05017, Aeronautical Radionavigation
+275000,       285000,       USB, 10, #994C8E75, Maritime Radionavigation (Radio Beacons)
+275000,       285000,       USB, 10, #99C05017, Aeronautical Radionavigation
+285000,       300000,       USB, 10, #99C05017, Aeronautical Radionavigation (Radio Beacons)
+285000,       300000,       USB, 10, #994C8E75, Maritime Radionavigation (Radio Beacons)
+300000,       325000,       USB, 10, #99C05017, Aeronautical Radionavigation (Radio Beacons)
+300000,       325000,       USB, 10, #994C8E75, Maritime Radionavigation (Radio Beacons)
+325000,       335000,       USB, 10, #99C05017, Aeronautical Radionavigation (Radio Beacons)
+325000,       335000,       USB, 10, #994C8E75, Maritime Radionavigation (Radio Beacons)
+335000,       405000,       USB, 10, #99C05017, Aeronautical Radionavigation (Radio Beacons)
+405000,       415000,       USB, 10, #99AABD26, Radionavigation
+415000,       495000,       USB, 10, #99C05017, Aeronautical Radionavigation
+510000,       535000,       USB, 10, #99C05017, Aeronautical Radionavigation (Radio Beacons)
+74800000,     75200000,     USB, 10, #99C05017, Aeronautical Radionavigation
+328600000,    335400000,    USB, 10, #99C05017, Aeronautical Radionavigation
+399900000,    400050000,    USB, 10, #99E9EB7C, Radionavigation Satellite
+960000000,    1215000000,   USB, 10, #99C05017, Aeronautical Radionavigation
+1215000000,   1240000000,   USB, 10, #99E9EB7C, Radionavigation Satellite
+1300000000,   1350000000,   USB, 10, #99C05017, Aeronautical Radionavigation
+1559000000,   1610000000,   USB, 10, #99E9EB7C, Radionavigation Satellite (Space to Earth)
+1559000000,   1626500000,   USB, 10, #99C05017, Aeronautical Radionavigation
+2700000000,   2900000000,   USB, 10, #99C05017, Aeronautical Radionavigation
+2900000000,   3100000000,   USB, 10, #994C8E75, Maritime Radionavigation
+3500000000,   3650000000,   USB, 10, #99C05017, Aeronautical Radionavigation (Ground)
+4200000000,   4400000000,   USB, 10, #99C05017, Aeronautical Radionavigation
+5000000000,   5250000000,   USB, 10, #99C05017, Aeronautical Radionavigation
+5350000000,   5460000000,   USB, 10, #99C05017, Aeronautical Radionavigation
+5460000000,   5470000000,   USB, 10, #99AABD26, Radionavigation
+5470000000,   5650000000,   USB, 10, #994C8E75, Maritime Radionavigation
+9000000000,   9200000000,   USB, 10, #99C05017, Aeronautical Radionavigation
+9200000000,   9300000000,   USB, 10, #994C8E75, Maritime Radionavigation
+9300000000,   9500000000,   USB, 10, #99AABD26, Radionavigation
+13250000000,  13400000000,  USB, 10, #99C05017, Aeronautical Radionavigation
+14000000000,  14200000000,  USB, 10, #99AABD26, Radionavigation
+15400000000,  15700000000,  USB, 10, #99C05017, Aeronautical Radionavigation
+24450000000,  24650000000,  USB, 10, #99AABD26, Radionavigation
+24750000000,  25050000000,  USB, 10, #99AABD26, Radionavigation
+31800000000,  33400000000,  USB, 10, #99AABD26, Radionavigation
+45500000000,  47000000000,  USB, 10, #99E9EB7C, Radionavigation Satellite
+66000000000,  71000000000,  USB, 10, #99AABD26, Radionavigation
+66000000000,  71000000000,  USB, 10, #99E9EB7C, Radionavigation Satellite
+95000000000,  100000000000, USB, 10, #99AABD26, Radionavigation
+95000000000,  100000000000, USB, 10, #99E9EB7C, Radionavigation Satellite
+134000000000, 142000000000, USB, 10, #99E9EB7C, Radionavigation Satellite
+134000000000, 142000000000, USB, 10, #99AABD26, Radionavigation
+190000000000, 200000000000, USB, 10, #99E9EB7C, Radionavigation Satellite
+190000000000, 200000000000, USB, 10, #99AABD26, Radionavigation
+252000000000, 265000000000, USB, 10, #99E9EB7C, Radionavigation Satellite
+252000000000, 265000000000, USB, 10, #99AABD26, Radionavigation
+
+# Broadcast
+54000000,  72000000,  AM,  10, #902E98BB, Broadcast Television
+76000000,  088000000, AM,  10, #902E98BB, Broadcast Television
+88000000,  108000000, WFM, 10, #902E98BB, Broadcast Radio
+174000000, 216000000, AM,  10, #902E98BB, Broadcast Television
+470000000, 512000000, AM,  10, #902E98BB, Broadcast Television
+512000000, 608000000, AM,  10, #902E98BB, Broadcast Television
+614000000, 698000000, AM,  10, #902E98BB, Broadcast Television
+698000000, 763000000, AM,  10, #902E98BB, Broadcast Television
+
+# Other
+108000000, 118000000, AM,   5000, #906600FF, Air Band VOR/ILS
+118000000, 137000000, AM,   5000, #900000FF, Air Band Voice
+26960000,   27410000, AM,   5000, #90FF0000, CB
+156000000, 162025000, NFM, 12500, #90000080, Marine
+225000000, 380000000, NFM, 12500, #90FF0000, Military Air
+240000000, 270000000, NFM, 12500, #90FF0000, Mil Sat
+446000000, 446200000, NFM,  6250, #9000FF00, PMR446

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -5,6 +5,7 @@
        NEW: Device scan button in Configure I/O devices dialog.
        NEW: Added "Recent settings" menu.
        NEW: Added synchronous AM demodulator.
+       NEW: Add band plan to bottom of FFT.
      FIXED: PortAudio detection on MacOS.
 
 

--- a/resources/textfiles.qrc
+++ b/resources/textfiles.qrc
@@ -2,5 +2,6 @@
     <qresource prefix="/textfiles">
         <file>news.txt</file>
         <file>remote-control.txt</file>
+        <file>bandplan.csv</file>
     </qresource>
 </RCC>

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -57,6 +57,7 @@
 #include "remote_control_settings.h"
 
 #include "qtgui/bookmarkstaglist.h"
+#include "qtgui/bandplan.h"
 
 MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     QMainWindow(parent),
@@ -69,6 +70,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     dec_afsk1200(0)
 {
     ui->setupUi(this);
+    BandPlan::create();
     Bookmarks::create();
 
     /* Initialise default configuration directory */
@@ -128,7 +130,9 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     uiDockAudio = new DockAudio();
     uiDockInputCtl = new DockInputCtl();
     uiDockFft = new DockFft();
+    BandPlan::Get().setConfigDir(m_cfg_dir);
     Bookmarks::Get().setConfigDir(m_cfg_dir);
+    BandPlan::Get().load();
     uiDockBookmarks = new DockBookmarks(this);
 
     // setup some toggle view shortcuts
@@ -239,6 +243,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(uiDockFft, SIGNAL(resetFftZoom()), ui->plotter, SLOT(resetHorizontalZoom()));
     connect(uiDockFft, SIGNAL(gotoFftCenter()), ui->plotter, SLOT(moveToCenterFreq()));
     connect(uiDockFft, SIGNAL(gotoDemodFreq()), ui->plotter, SLOT(moveToDemodFreq()));
+    connect(uiDockFft, SIGNAL(bandPlanChanged(bool)), ui->plotter, SLOT(toggleBandPlan(bool)));
     connect(uiDockFft, SIGNAL(wfColormapChanged(const QString)), ui->plotter, SLOT(setWfColormap(const QString)));
     connect(uiDockFft, SIGNAL(wfColormapChanged(const QString)), uiDockAudio, SLOT(setWfColormap(const QString)));
 

--- a/src/qtgui/CMakeLists.txt
+++ b/src/qtgui/CMakeLists.txt
@@ -7,6 +7,8 @@ add_source_files(SRCS_LIST
 	agc_options.h
 	audio_options.cpp
 	audio_options.h
+	bandplan.cpp
+	bandplan.h
 	bookmarks.cpp
 	bookmarks.h
 	bookmarkstablemodel.cpp

--- a/src/qtgui/bandplan.cpp
+++ b/src/qtgui/bandplan.cpp
@@ -35,7 +35,7 @@ BandPlan* BandPlan::m_pThis = 0;
 
 BandPlan::BandPlan()
 {
-    
+
 }
 
 void BandPlan::create()
@@ -58,9 +58,9 @@ bool BandPlan::load()
 {
     QFile file(m_bandPlanFile);
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) return false;
-    
+
     m_BandInfoList.clear();
-    
+
     while (!file.atEnd())
     {
         QString line = QString::fromUtf8(file.readLine().trimmed());
@@ -69,7 +69,7 @@ bool BandPlan::load()
 
         QStringList strings = line.split(",");
 
-        if (strings.count() < 6){
+        if (strings.count() < 6) {
             printf("BandPlan: Ignoring Line:\n  %s\n", line.toLatin1().data());
         } else {
             BandInfo info;
@@ -84,7 +84,7 @@ bool BandPlan::load()
         }
     }
     file.close();
-    
+
     emit BandPlanChanged();
     return true;
 }

--- a/src/qtgui/bandplan.cpp
+++ b/src/qtgui/bandplan.cpp
@@ -1,0 +1,112 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2013 Christian Lindner DL2VCL, Stefano Leucci.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#include <Qt>
+#include <QFile>
+#include <QStringList>
+#include <QTextStream>
+#include <QString>
+#include <QSet>
+#include <algorithm>
+#include "bandplan.h"
+#include <stdio.h>
+#include <wchar.h>
+
+BandPlan* BandPlan::m_pThis = 0;
+
+BandPlan::BandPlan()
+{
+    
+}
+
+void BandPlan::create()
+{
+    m_pThis = new BandPlan;
+}
+
+BandPlan& BandPlan::Get()
+{
+    return *m_pThis;
+}
+
+void BandPlan::setConfigDir(const QString& cfg_dir)
+{
+    m_bandPlanFile = cfg_dir + "/bandplan.csv";
+    printf("BandPlanFile is %s\n", m_bandPlanFile.toStdString().c_str());
+}
+
+bool BandPlan::load()
+{
+    QFile file(m_bandPlanFile);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) return false;
+    
+    m_BandInfoList.clear();
+    
+    while (!file.atEnd())
+    {
+        QString line = QString::fromUtf8(file.readLine().trimmed());
+        if(line.isEmpty() || line.startsWith("#"))
+            continue;
+
+        QStringList strings = line.split(",");
+
+        if (strings.count() < 6){
+            printf("BandPlan: Ignoring Line:\n  %s\n", line.toLatin1().data());
+        } else {
+            BandInfo info;
+            info.minFrequency = strings[0].toLongLong();
+            info.maxFrequency = strings[1].toLongLong();
+            info.modulation   = strings[2].trimmed();
+            info.step         = strings[3].toInt();
+            info.color        = QColor(strings[4].trimmed());
+            info.name         = strings[5].trimmed();
+
+            m_BandInfoList.append(info);
+        }
+    }
+    file.close();
+    
+    emit BandPlanChanged();
+    return true;
+}
+
+QList<BandInfo> BandPlan::getBandsInRange(qint64 low, qint64 high)
+{
+    QList<BandInfo> found;
+    for (int i = 0; i < m_BandInfoList.size(); i++) {
+        if(m_BandInfoList[i].maxFrequency < low) continue;
+        if(m_BandInfoList[i].minFrequency > high) continue;
+        found.append(m_BandInfoList[i]);
+    }
+    return found;
+}
+
+QList<BandInfo> BandPlan::getBandsEncompassing(qint64 freq)
+{
+    QList<BandInfo> found;
+    for (int i = 0; i < m_BandInfoList.size(); i++) {
+        if(m_BandInfoList[i].maxFrequency < freq) continue;
+        if(m_BandInfoList[i].minFrequency > freq) continue;
+        found.append(m_BandInfoList[i]);
+    }
+    return found;
+}

--- a/src/qtgui/bandplan.cpp
+++ b/src/qtgui/bandplan.cpp
@@ -3,7 +3,7 @@
  * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
  *           http://gqrx.dk/
  *
- * Copyright 2013 Christian Lindner DL2VCL, Stefano Leucci.
+ * Copyright 2020 Dallas Epperson.
  *
  * Gqrx is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/qtgui/bandplan.cpp
+++ b/src/qtgui/bandplan.cpp
@@ -22,6 +22,7 @@
  */
 #include <Qt>
 #include <QFile>
+#include <QResource>
 #include <QStringList>
 #include <QTextStream>
 #include <QString>
@@ -52,6 +53,13 @@ void BandPlan::setConfigDir(const QString& cfg_dir)
 {
     m_bandPlanFile = cfg_dir + "/bandplan.csv";
     printf("BandPlanFile is %s\n", m_bandPlanFile.toStdString().c_str());
+
+    if (!QFile::exists(m_bandPlanFile))
+    {
+        QResource resource(":/textfiles/bandplan.csv");
+        QFile::copy(resource.absoluteFilePath(), m_bandPlanFile);
+        QFile::setPermissions(m_bandPlanFile, QFile::permissions(m_bandPlanFile) | QFile::WriteOwner);
+    }
 }
 
 bool BandPlan::load()

--- a/src/qtgui/bandplan.h
+++ b/src/qtgui/bandplan.h
@@ -1,0 +1,83 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2013 Christian Lindner DL2VCL, Stefano Leucci.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef BANDPLAN_H
+#define BANDPLAN_H
+
+#include <QtGlobal>
+#include <QObject>
+#include <QString>
+#include <QMap>
+#include <QList>
+#include <QStringList>
+#include <QColor>
+
+
+
+struct BandInfo
+{
+    qint64  minFrequency;
+    qint64  maxFrequency;
+    QString name;
+    QString modulation;
+    qint64  step;
+    QColor  color;
+
+    BandInfo()
+    {
+        this->minFrequency = 0;
+        this->maxFrequency = 0;
+        this->step = 1;
+    }
+
+    bool operator<(const BandInfo &other) const
+    {
+        return minFrequency < other.minFrequency;
+    }
+};
+
+class BandPlan : public QObject
+{
+    Q_OBJECT
+public:
+    // This is a Singleton Class now because you can not send qt-signals from static functions.
+    static void create();
+    static BandPlan& Get();
+    bool load();
+    int size() { return m_BandInfoList.size(); }
+    BandInfo& getBand(int i) { return m_BandInfoList[i]; }
+    QList<BandInfo> getBandsInRange(qint64 low, qint64 high);
+    QList<BandInfo> getBandsEncompassing(qint64 freq);
+
+    void setConfigDir(const QString&);
+
+private:
+    BandPlan(); // Singleton Constructor is private.
+    QList<BandInfo>  m_BandInfoList;
+    QString          m_bandPlanFile;
+    static BandPlan* m_pThis;
+
+signals:
+    void BandPlanChanged(void);
+};
+
+#endif // BANDPLAN_H

--- a/src/qtgui/bandplan.h
+++ b/src/qtgui/bandplan.h
@@ -31,8 +31,6 @@
 #include <QStringList>
 #include <QColor>
 
-
-
 struct BandInfo
 {
     qint64  minFrequency;

--- a/src/qtgui/bandplan.h
+++ b/src/qtgui/bandplan.h
@@ -3,7 +3,7 @@
  * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
  *           http://gqrx.dk/
  *
- * Copyright 2013 Christian Lindner DL2VCL, Stefano Leucci.
+ * Copyright 2020 Dallas Epperson.
  *
  * Gqrx is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -74,6 +74,7 @@ DockAudio::DockAudio(QWidget *parent) :
     ui->audioSpectrum->setFilterBoxEnabled(false);
     ui->audioSpectrum->setCenterLineEnabled(false);
     ui->audioSpectrum->setBookmarksEnabled(false);
+    ui->audioSpectrum->setBandPlanEnabled(false);
     ui->audioSpectrum->setFftRange(-80., 0.);
     ui->audioSpectrum->setVdivDelta(40);
     ui->audioSpectrum->setHdivDelta(40);

--- a/src/qtgui/dockfft.cpp
+++ b/src/qtgui/dockfft.cpp
@@ -268,6 +268,12 @@ void DockFft::saveSettings(QSettings *settings)
     else
         settings->remove("db_ranges_locked");
 
+    // Band Plan
+    if (ui->bandPlanCheckbox->isChecked())
+        settings->setValue("bandplan", true);
+    else
+        settings->remove("bandplan");
+
     if (QString::compare(ui->cmapComboBox->currentData().toString(), DEFAULT_COLORMAP))
         settings->setValue("waterfall_colormap", ui->cmapComboBox->currentData().toString());
     else
@@ -339,6 +345,10 @@ void DockFft::readSettings(QSettings *settings)
 
     bool_val = settings->value("db_ranges_locked", false).toBool();
     ui->lockButton->setChecked(bool_val);
+
+    bool_val = settings->value("bandplan", false).toBool();
+    ui->bandPlanCheckbox->setChecked(bool_val);
+    emit bandPlanChanged(bool_val);
 
     QString cmap = settings->value("waterfall_colormap", "gqrx").toString();
     ui->cmapComboBox->setCurrentIndex(ui->cmapComboBox->findData(cmap));
@@ -514,6 +524,11 @@ void DockFft::on_peakHoldButton_toggled(bool checked)
 void DockFft::on_peakDetectionButton_toggled(bool checked)
 {
     emit peakDetectionToggled(checked);
+}
+
+void DockFft::on_bandPlanCheckbox_stateChanged(int state)
+{
+    emit bandPlanChanged(state == 2);
 }
 
 /** lock button toggled */

--- a/src/qtgui/dockfft.h
+++ b/src/qtgui/dockfft.h
@@ -67,6 +67,7 @@ signals:
     void fftFillToggled(bool fill);                /*! Toggle filling area under FFT plot. */
     void fftPeakHoldToggled(bool enable);          /*! Toggle peak hold in FFT area. */
     void peakDetectionToggled(bool enabled);       /*! Enable peak detection in FFT plot */
+    void bandPlanChanged(bool enabled);            /*! Toggle Band Plan at bottom of FFT area. */
     void wfColormapChanged(const QString &cmap);
 
 public slots:
@@ -93,6 +94,7 @@ private slots:
     void on_peakHoldButton_toggled(bool checked);
     void on_peakDetectionButton_toggled(bool checked);
     void on_lockButton_toggled(bool checked);
+    void on_bandPlanCheckbox_stateChanged(int state);
     void on_cmapComboBox_currentIndexChanged(int index);
 
 private:

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -851,7 +851,7 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="0" colspan="4">
+          <item row="15" column="0" colspan="4">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -939,8 +939,7 @@
              </size>
             </property>
             <property name="toolTip">
-             <string>&lt;html&gt;Number of FFT points to calculate. Higher values will require more CPU time. This will not influence the number of points on the display since that parameter is adjusted automatically according to the display size.
-&lt;/html&gt;</string>
+             <string>&lt;html&gt;Number of FFT points to calculate. Higher values will require more CPU time. This will not influence the number of points on the display since that parameter is adjusted automatically according to the display size.&lt;/html&gt;</string>
             </property>
             <property name="editable">
              <bool>false</bool>
@@ -1106,6 +1105,16 @@
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
            </widget>
+          </item>
+          <item row="14" column="0" colspan="4">
+            <widget class="QCheckBox" name="bandPlanCheckbox">
+              <property name="toolTip">
+                <string>Enable Band Plan on bottom of spectrum</string>
+              </property>
+              <property name="text">
+                <string>Enable Band Plan</string>
+              </property>
+            </widget>
           </item>
          </layout>
         </item>

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -39,6 +39,7 @@ public:
     void setTooltipsEnabled(bool enabled) { m_TooltipsEnabled = enabled; }
     void setBookmarksEnabled(bool enabled) { m_BookmarksEnabled = enabled; }
     void setInvertScrolling(bool enabled) { m_InvertScrolling = enabled; }
+    void setBandPlanEnabled(bool enabled) { m_BandPlanEnabled = enabled; }
 
     void setNewFftData(float *fftData, int size);
     void setNewFftData(float *fftData, float *wfData, int size);
@@ -147,6 +148,7 @@ public slots:
     void setPandapterRange(float min, float max);
     void setWaterfallRange(float min, float max);
     void setPeakDetection(bool enabled, float c);
+    void toggleBandPlan(bool state);
     void updateOverlay();
 
     void setPercent2DScreen(int percent)
@@ -224,7 +226,8 @@ private:
     qint64      m_FreqPerDiv;
     bool        m_CenterLineEnabled;  /*!< Distinguish center line. */
     bool        m_FilterBoxEnabled;   /*!< Draw filter box. */
-    bool        m_TooltipsEnabled;     /*!< Tooltips enabled */
+    bool        m_TooltipsEnabled;    /*!< Tooltips enabled */
+    bool        m_BandPlanEnabled;    /*!< Show/hide band plan on spectrum */
     bool        m_BookmarksEnabled;   /*!< Show/hide bookmarks on spectrum */
     bool        m_InvertScrolling;
     int         m_DemodHiCutFreq;
@@ -263,6 +266,7 @@ private:
     QFont       m_Font;         /*!< Font used for plotter (system font) */
     int         m_HdivDelta; /*!< Minimum distance in pixels between two horizontal grid lines (vertical division). */
     int         m_VdivDelta; /*!< Minimum distance in pixels between two vertical grid lines (horizontal division). */
+    int         m_BandPlanHeight; /*!< Height in pixels of band plan (if enabled) */
 
     quint32     m_LastSampleRate;
 


### PR DESCRIPTION
Picked up where #621 left off, with a few changes. 

![image](https://user-images.githubusercontent.com/3578478/75723450-5a747a00-5caa-11ea-830c-304468ae9434.png)


Previous implementation was reading from resources file every time frequency was scrolled, resized, or refocused. Instead, I am reading from user's config directory on application start. I chose to use the user's config directory instead of application resource file because each user may wish to have their own bands configured due to different allocations for different regions, etc.

Band Plan configuration file follows this pattern:
`/home/dallas/.config/gqrx/bandplan.csv`
```
# minFrequency,maxFrequency,mode,step,color,name

# USA Amateur Radio
135700,       137800,       CW,  10, #90009470, 2200m Ham Band
472000,       479000,       CW,  10, #90009470, 630m Ham Band
1800000,      2000000,      CW,  10, #90009470, 160m Ham Band
3500000,      3600000,      CW,  10, #90009470, 80m CW/Data Ham Band
3600000,      4000000,      CW,  10, #90009470, 80m Phone Ham Band
5351500,      5366500,      USB, 10, #90009470, 60m Ham Band
[.. removed for brevity ...]
241000000000, 250000000000, NFM, 10, #90009470, GHz Ham Band

# Radionavigation - Source: https://www.ntia.doc.gov/files/ntia/publications/2003-allochrt.pdf
9000,         14000,        USB, 10, #99AABD26, Radionavigation
90000,        110000,       USB, 10, #99AABD26, Radionavigation
190000,       200000,       USB, 10, #99C05017, Aeronautical Radionavigation
[... removed for brevity ...]
9000000000,   9200000000,   USB, 10, #99C05017, Aeronautical Radionavigation
9200000000,   9300000000,   USB, 10, #994C8E75, Maritime Radionavigation
9300000000,   9500000000,   USB, 10, #99AABD26, Radionavigation
[... removed for brevity ...]
252000000000, 265000000000, USB, 10, #99E9EB7C, Radionavigation Satellite
252000000000, 265000000000, USB, 10, #99AABD26, Radionavigation

# Broadcast
54000000,  72000000,  AM,  10, #902E98BB, Broadcast Television
76000000,  088000000, AM,  10, #902E98BB, Broadcast Television
88000000,  108000000, WFM, 10, #902E98BB, Broadcast Radio
174000000, 216000000, AM,  10, #902E98BB, Broadcast Television
470000000, 512000000, AM,  10, #902E98BB, Broadcast Television
512000000, 608000000, AM,  10, #902E98BB, Broadcast Television
614000000, 698000000, AM,  10, #902E98BB, Broadcast Television
698000000, 763000000, AM,  10, #902E98BB, Broadcast Television

# Other
108000000, 118000000,AM, 5000, #900000FF, Air Band VOR/ILS
118000000, 137000000,AM, 5000, #900000FF, Air Band Voice
26960000,  27410000, AM, 5000, #90FF0000, CB
156000000, 162025000,NFM,12500,#90000080, Marine
225000000, 380000000,NFM,12500,#90FF0000, Military Air
240000000, 270000000,NFM,12500,#90FF0000, Mil Sat
446000000, 446200000,NFM,6250, #9000FF00, PMR446
```
Spaces are trimmed, leading zeros are optional. Colors are in `#AARRBBGG` format.

Currently, the band plan configuration file is not editable by GQRX, but I can work on that if it is desired. 

This should resolve #205, #265. 