### PR TITLE
New feature FrequencyHistory

### DIFF
--- a/gqrx.pro
+++ b/gqrx.pro
@@ -92,6 +92,8 @@ VERSTR = '\\"$${VER}\\"'          # place quotes around the version string
 DEFINES += VERSION=\"$${VERSTR}\" # create a VERSION macro containing the version string
 
 SOURCES += \
+    src/applications/gqrx/freqhistory.cpp \
+    src/applications/gqrx/freqhistoryentry.cpp \
     src/applications/gqrx/main.cpp \
     src/applications/gqrx/mainwindow.cpp \
     src/applications/gqrx/receiver.cpp \
@@ -147,6 +149,8 @@ SOURCES += \
     src/receivers/wfmrx.cpp
 
 HEADERS += \
+    src/applications/gqrx/freqhistory.h \
+    src/applications/gqrx/freqhistoryentry.h \
     src/applications/gqrx/gqrx.h \
     src/applications/gqrx/mainwindow.h \
     src/applications/gqrx/receiver.h \

--- a/resources/icons.qrc
+++ b/resources/icons.qrc
@@ -21,5 +21,7 @@
         <file>icons/signal.svg</file>
         <file>icons/tangeo-network-idle.svg</file>
         <file>icons/terminal.svg</file>
+        <file>icons/forward.svg</file>
+        <file>icons/backward.svg</file>
     </qresource>
 </RCC>

--- a/resources/icons/backward.svg
+++ b/resources/icons/backward.svg
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg7854"
+   sodipodi:version="0.32"
+   inkscape:version="0.45"
+   version="1.0"
+   sodipodi:docbase="/home/dobey/Projects/gnome-icon-theme/scalable/actions"
+   sodipodi:docname="media-seek-backward.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   inkscape:export-filename="/home/lapo/Desktop/media-icons.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs7856">
+    <linearGradient
+       id="linearGradient7577">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.3137255;"
+         offset="0"
+         id="stop7579" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop7581" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7305">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop7307" />
+      <stop
+         id="stop7313"
+         offset="0.20971029"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.81065089;"
+         offset="0.34936365"
+         id="stop7329" />
+      <stop
+         id="stop7321"
+         offset="0.42850056"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.52134049"
+         id="stop7323" />
+      <stop
+         id="stop7317"
+         offset="0.55746967"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.56804734;"
+         offset="0.71001518"
+         id="stop7319" />
+      <stop
+         id="stop7416"
+         offset="0.74394959"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1"
+         id="stop7309" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7344"
+       inkscape:collect="always">
+      <stop
+         id="stop7346"
+         offset="0"
+         style="stop-color:#eeeeec;stop-opacity:1" />
+      <stop
+         id="stop7348"
+         offset="1"
+         style="stop-color:#92948f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7577"
+       id="linearGradient8098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,-250.51531,0)"
+       x1="-127.01692"
+       y1="12.838128"
+       x2="-123.49838"
+       y2="25.969481" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7344"
+       id="radialGradient8100"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.9143326,0,0,1.5917714,100.35131,1.6193442e-2)"
+       cx="38.40033"
+       cy="17.833462"
+       fx="38.40033"
+       fy="17.833462"
+       r="13.55237" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7344"
+       id="radialGradient8102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.9143326,0,0,1.5917714,100.35131,1.6193442e-2)"
+       cx="38.40033"
+       cy="17.833462"
+       fx="38.40033"
+       fy="17.833462"
+       r="13.55237" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7305"
+       id="linearGradient8104"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,-302,48)"
+       x1="52.331951"
+       y1="10.440893"
+       x2="100.16806"
+       y2="38.059086" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#afafaf"
+     borderopacity="1"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="-137.53856"
+     inkscape:cy="10.827794"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     width="48px"
+     height="48px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="872"
+     inkscape:window-height="971"
+     inkscape:window-x="117"
+     inkscape:window-y="27"
+     showgrid="false"
+     gridspacingx="0.5px"
+     gridspacingy="0.5px"
+     gridempspacing="2"
+     inkscape:grid-points="true"
+     showborder="true"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     borderlayer="true">
+    <sodipodi:guide
+       orientation="horizontal"
+       position="13.125"
+       id="guide7377" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="5.4800776"
+       id="guide7379" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="35"
+       id="guide7492" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="48"
+       id="guide7046" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="-17.5"
+       id="guide7233" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="-29"
+       id="guide7235" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="22.097087"
+       id="guide7556" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-76.125"
+       id="guide7644" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-26.125"
+       id="guide7646" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="24"
+       id="guide7648" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-125.28125"
+       id="guide7665" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-175.125"
+       id="guide7667" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-225.83223"
+       id="guide7685" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-326.06462"
+       id="guide7695" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7859">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Lapo Calamandrei</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/GPL/2.0/" />
+        <dc:title>Rewind</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>rewind</rdf:li>
+            <rdf:li>seek</rdf:li>
+            <rdf:li>backward</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/GPL/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/SourceCode" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g7145"
+       transform="translate(250,0)">
+      <path
+         transform="matrix(-1,0,0,1,-351.01531,0)"
+         d="M -143.75,11.53125 C -144.47126,11.646642 -145.00141,12.269567 -145,13 L -145,35 C -145.00337,35.536848 -144.71663,36.033688 -144.25011,36.299347 C -143.78358,36.565005 -143.20998,36.558085 -142.75,36.28125 L -127,26.9375 L -127,35 C -127.00337,35.536848 -126.71663,36.033688 -126.25011,36.299347 C -125.78358,36.565005 -125.20998,36.558085 -124.75,36.28125 L -106.25,25.28125 C -105.79494,25.014944 -105.51528,24.527253 -105.51528,24 C -105.51528,23.472747 -105.79494,22.985056 -106.25,22.71875 L -124.75,11.71875 C -125.20998,11.441915 -125.78358,11.434995 -126.25011,11.700653 C -126.71663,11.966312 -127.00337,12.463152 -127,13 L -127,21.0625 L -142.75,11.71875 C -143.05084,11.540409 -143.40499,11.474007 -143.75,11.53125 L -143.75,11.53125 z "
+         id="path7681"
+         style="opacity:0.4;fill:url(#linearGradient8098);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+         inkscape:original="M -143.5 13 L -143.5 35 L -125.5 24.3125 L -125.5 35 L -107 24 L -125.5 13 L -125.5 23.6875 L -143.5 13 z "
+         inkscape:radius="1.484375"
+         sodipodi:type="inkscape:offset" />
+      <g
+         id="g7530">
+        <g
+           id="g7964"
+           transform="translate(-132,0)">
+          <g
+             transform="matrix(-1,0,0,1,-54,0)"
+             id="g7952">
+            <path
+               style="fill:url(#radialGradient8100);fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               d="M 21.5,35 L 21.5,13.000461 L 39.995767,24.010194 L 21.5,35 z "
+               id="path7954"
+               sodipodi:nodetypes="cccc" />
+            <path
+               sodipodi:type="inkscape:offset"
+               inkscape:radius="-1.0054175"
+               inkscape:original="M 21.5 13 L 21.5 35 L 40 24 L 21.5 13 z "
+               style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               id="path7956"
+               d="M 22.5,14.78125 L 22.5,33.21875 L 38.03125,24 L 22.5,14.78125 z " />
+          </g>
+          <g
+             transform="matrix(-1,0,0,1,-72,0)"
+             id="g7958">
+            <path
+               style="fill:url(#radialGradient8102);fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               d="M 21.5,35 L 21.5,13.000461 L 39.995767,24.010194 L 21.5,35 z "
+               id="path7960"
+               sodipodi:nodetypes="cccc" />
+            <path
+               sodipodi:type="inkscape:offset"
+               inkscape:radius="-1.0054175"
+               inkscape:original="M 21.5 13 L 21.5 35 L 40 24 L 21.5 13 z "
+               style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               id="path7962"
+               d="M 22.5,14.78125 L 22.5,33.21875 L 38.03125,24 L 22.5,14.78125 z " />
+          </g>
+        </g>
+        <path
+           style="opacity:0.15;fill:url(#linearGradient8104);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+           d="M -226,34.125 L -243.03125,24 L -226,13.875 L -226,23.6875 C -225.99616,23.803079 -225.95193,23.913655 -225.875,24 C -225.95193,24.086345 -225.99616,24.196921 -226,24.3125 L -226,34.125 z M -208,34.125 L -225.03125,24 L -208,13.875 L -208,34.125 z "
+           id="path7331"
+           sodipodi:nodetypes="ccccccccccc" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/resources/icons/forward.svg
+++ b/resources/icons/forward.svg
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://web.resource.org/cc/"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg7854"
+   sodipodi:version="0.32"
+   inkscape:version="0.45"
+   version="1.0"
+   sodipodi:docbase="/home/dobey/Projects/gnome-icon-theme/scalable/actions"
+   sodipodi:docname="media-seek-forward.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   inkscape:export-filename="/home/lapo/Desktop/media-icons.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs7856">
+    <linearGradient
+       id="linearGradient7577">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.3137255;"
+         offset="0"
+         id="stop7579" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop7581" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7305">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop7307" />
+      <stop
+         id="stop7313"
+         offset="0.20971029"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.81065089;"
+         offset="0.34936365"
+         id="stop7329" />
+      <stop
+         id="stop7321"
+         offset="0.42850056"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.52134049"
+         id="stop7323" />
+      <stop
+         id="stop7317"
+         offset="0.55746967"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.56804734;"
+         offset="0.71001518"
+         id="stop7319" />
+      <stop
+         id="stop7416"
+         offset="0.74394959"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1"
+         id="stop7309" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7344"
+       inkscape:collect="always">
+      <stop
+         id="stop7346"
+         offset="0"
+         style="stop-color:#eeeeec;stop-opacity:1" />
+      <stop
+         id="stop7348"
+         offset="1"
+         style="stop-color:#92948f;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7577"
+       id="linearGradient7871"
+       gradientUnits="userSpaceOnUse"
+       x1="-127.01692"
+       y1="12.838128"
+       x2="-123.49838"
+       y2="25.969481" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7344"
+       id="radialGradient7873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8811669,0,0,1.5641941,82.169231,0.3959845)"
+       cx="36.455379"
+       cy="17.414564"
+       fx="36.455379"
+       fy="17.414564"
+       r="13.55237" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7344"
+       id="radialGradient7875"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8811669,0,0,1.5641941,82.169231,0.3959845)"
+       cx="36.455379"
+       cy="17.414564"
+       fx="36.455379"
+       fy="17.414564"
+       r="13.55237" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7305"
+       id="linearGradient7877"
+       gradientUnits="userSpaceOnUse"
+       x1="-0.0034508049"
+       y1="10.04301"
+       x2="48.128452"
+       y2="37.831978" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#afafaf"
+     borderopacity="1"
+     gridtolerance="10000"
+     guidetolerance="10"
+     objecttolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="-137.53856"
+     inkscape:cy="10.827794"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     width="48px"
+     height="48px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="872"
+     inkscape:window-height="971"
+     inkscape:window-x="117"
+     inkscape:window-y="27"
+     showgrid="false"
+     gridspacingx="0.5px"
+     gridspacingy="0.5px"
+     gridempspacing="2"
+     inkscape:grid-points="true"
+     showborder="true"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     borderlayer="true">
+    <sodipodi:guide
+       orientation="horizontal"
+       position="13.125"
+       id="guide7377" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="5.4800776"
+       id="guide7379" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="35"
+       id="guide7492" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="48"
+       id="guide7046" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="-17.5"
+       id="guide7233" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="-29"
+       id="guide7235" />
+    <sodipodi:guide
+       orientation="horizontal"
+       position="22.097087"
+       id="guide7556" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-76.125"
+       id="guide7644" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-26.125"
+       id="guide7646" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="24"
+       id="guide7648" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-125.28125"
+       id="guide7665" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-175.125"
+       id="guide7667" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-225.83223"
+       id="guide7685" />
+    <sodipodi:guide
+       orientation="vertical"
+       position="-326.06462"
+       id="guide7695" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7859">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Lapo Calamandrei</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/GPL/2.0/" />
+        <dc:title>Fast Forward</dc:title>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>seek</rdf:li>
+            <rdf:li>forward</rdf:li>
+            <rdf:li>ff</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/GPL/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/SourceCode" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g7126"
+       transform="translate(150,0)">
+      <path
+         d="M -143.75,11.53125 C -144.47126,11.646642 -145.00141,12.269567 -145,13 L -145,35 C -145.00337,35.536848 -144.71663,36.033688 -144.25011,36.299347 C -143.78358,36.565005 -143.20998,36.558085 -142.75,36.28125 L -127,26.9375 L -127,35 C -127.00337,35.536848 -126.71663,36.033688 -126.25011,36.299347 C -125.78358,36.565005 -125.20998,36.558085 -124.75,36.28125 L -106.25,25.28125 C -105.79494,25.014944 -105.51528,24.527253 -105.51528,24 C -105.51528,23.472747 -105.79494,22.985056 -106.25,22.71875 L -124.75,11.71875 C -125.20998,11.441915 -125.78358,11.434995 -126.25011,11.700653 C -126.71663,11.966312 -127.00337,12.463152 -127,13 L -127,21.0625 L -142.75,11.71875 C -143.05084,11.540409 -143.40499,11.474007 -143.75,11.53125 L -143.75,11.53125 z "
+         id="path7659"
+         style="opacity:0.4;fill:url(#linearGradient7871);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+         inkscape:original="M -143.5 13 L -143.5 35 L -125.5 24.3125 L -125.5 35 L -107 24 L -125.5 13 L -125.5 23.6875 L -143.5 13 z "
+         inkscape:radius="1.484375"
+         sodipodi:type="inkscape:offset" />
+      <g
+         id="g7498">
+        <g
+           id="g8037"
+           transform="translate(-267,0)">
+          <g
+             transform="translate(-18,0)"
+             id="g8025">
+            <path
+               style="fill:url(#radialGradient7873);fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               d="M 141.5,35 L 141.5,13.000461 L 159.99577,24.010194 L 141.5,35 z "
+               id="path8027"
+               sodipodi:nodetypes="cccc" />
+            <path
+               sodipodi:type="inkscape:offset"
+               inkscape:radius="-1.0054175"
+               inkscape:original="M 21.5 13 L 21.5 35 L 40 24 L 21.5 13 z "
+               style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               id="path8029"
+               d="M 22.5,14.78125 L 22.5,33.21875 L 38.03125,24 L 22.5,14.78125 z "
+               transform="translate(120,0)" />
+          </g>
+          <g
+             id="g8031">
+            <path
+               style="fill:url(#radialGradient7875);fill-opacity:1;fill-rule:evenodd;stroke:#555753;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               d="M 141.5,35 L 141.5,13.000461 L 159.99577,24.010194 L 141.5,35 z "
+               id="path8033"
+               sodipodi:nodetypes="cccc" />
+            <path
+               sodipodi:type="inkscape:offset"
+               inkscape:radius="-1.0054175"
+               inkscape:original="M 21.5 13 L 21.5 35 L 40 24 L 21.5 13 z "
+               style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+               id="path8035"
+               d="M 22.5,14.78125 L 22.5,33.21875 L 38.03125,24 L 22.5,14.78125 z "
+               transform="translate(120,0)" />
+          </g>
+        </g>
+        <path
+           sodipodi:type="inkscape:offset"
+           inkscape:radius="-0.5"
+           inkscape:original="M 6.5 13 L 6.5 35 L 24.5 24.3125 L 24.5 35 L 43 24 L 24.5 13 L 24.5 23.6875 L 6.5 13 z "
+           style="opacity:0.15;fill:url(#linearGradient7877);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0.69999992;stroke-opacity:1"
+           id="path7369"
+           d="M 7,13.875 L 7,34.125 L 24.03125,24 L 7,13.875 z M 25,13.875 L 25,23.6875 C 24.995694,23.802981 24.951524,23.913406 24.875,24 C 24.951524,24.086594 24.995694,24.197019 25,24.3125 L 25,34.125 L 42,24 L 25,13.875 z "
+           transform="matrix(1,0,0,-1,-150,48)" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -1,6 +1,10 @@
 #######################################################################################################################
 # Add the source files to SRCS_LIST
 add_source_files(SRCS_LIST
+	gqrx/freqhistory.cpp
+	gqrx/freqhistory.h
+	gqrx/freqhistoryentry.cpp
+	gqrx/freqhistoryentry.h
 	gqrx/gqrx.h
 	gqrx/main.cpp
 	gqrx/mainwindow.cpp

--- a/src/applications/gqrx/freqhistory.cpp
+++ b/src/applications/gqrx/freqhistory.cpp
@@ -1,0 +1,181 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Markus Kolb
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "freqhistory.h"
+
+FreqHistory::FreqHistory() :
+    cache(new FHCache()),
+    tmp_entry_tstamp(QDateTime::currentDateTime().addMSecs(std::numeric_limits<qint64>::max())),
+    cur_index(-1)
+{
+}
+
+bool FreqHistory::back(FreqHistoryEntry &entry)
+{
+    store_tmp_entry();
+    if (cur_index > 0)
+    {
+        entry = *cache->at(--cur_index);
+        return true;
+    }
+    return false;
+}
+
+bool FreqHistory::forward(FreqHistoryEntry &entry)
+{
+    store_tmp_entry();
+    if (cache->count() > cur_index + 1)
+    {
+        entry = *cache->at(++cur_index);
+        return true;
+    }
+    return false;
+}
+
+bool FreqHistory::is_first()
+{
+    return cur_index <= 0;
+}
+
+bool FreqHistory::is_last()
+{
+    return cur_index < 0 || cur_index >= cache->count() - 1 || (tmp_entry && *cache->at(cur_index) != *tmp_entry);
+}
+
+int FreqHistory::position() const
+{
+    return cur_index;
+}
+
+int FreqHistory::size() const
+{
+    return cache->count();
+}
+
+void FreqHistory::sync()
+{
+    store_tmp_entry();
+}
+
+int FreqHistory::timeout_ms() const
+{
+    return FH_DEFAULT_TIMEOUT_MS;
+}
+
+void FreqHistory::try_make_entry(const FreqHistoryEntry &entry)
+{
+    store_tmp_entry();
+    tmp_entry_tstamp = QDateTime::currentDateTime().addMSecs(timeout_ms());
+    tmp_entry = FHCacheEntry(new FreqHistoryEntry(entry));
+
+#ifndef QT_NO_DEBUG_OUTPUT
+    qDebug() << "Modified tmp_entry: " << tmp_entry->freq_hz;
+#endif
+}
+
+int FreqHistory::cache_size()
+{
+    return FH_DEFAULT_SIZE;
+}
+
+void FreqHistory::cleanup()
+{
+    if (cache->empty())
+        return;
+
+    cache->resize(cur_index + 1);
+}
+
+void FreqHistory::make_entry(const FHCacheEntry &entry)
+{
+#ifndef QT_NO_DEBUG_OUTPUT
+    qDebug() << ">>> History [" << cache->count() << "] before:";
+    for (auto i = 0; i < cache->count(); i++)
+    {
+        qDebug() << " " << (i < 10 ? " " : "") << i << " " << *cache->at(i);
+    }
+    qDebug() << "<<<";
+#endif
+
+    if (cur_index >= 0 && *cache->at(cur_index) == *entry)
+    {
+        // entry already available
+        return;
+    }
+
+    if (cache->count() >= cache_size())
+    {
+        // max. history cache size reached, remove first (oldest)
+        cache->removeFirst();
+        cur_index -= 1; /* should stay >= 0, but it's checked with cache_size in if block */
+    }
+
+    cur_index++;
+
+    if (cache->count() > cur_index)
+    {
+        // in the middle of history cache
+        cache->replace(cur_index, entry);
+        cleanup();
+    }
+    else
+    {
+        cache->append(entry);
+    }
+
+#ifndef QT_NO_DEBUG_OUTPUT
+    qDebug() << ">>> History [" << cache->count() << "] afterwards:";
+    for (auto i = 0; i < cache->count(); i++)
+    {
+        qDebug() << " " << (i < 10 ? " " : "") << i << " " << *cache->at(i);
+    }
+    qDebug() << "<<<";
+#endif
+}
+
+void FreqHistory::store_tmp_entry()
+{
+    if (tmp_entry && tmp_entry_tstamp.toMSecsSinceEpoch() <= QDateTime::currentMSecsSinceEpoch())
+    {
+        make_entry(tmp_entry);
+        // set far in future
+        tmp_entry_tstamp = QDateTime::currentDateTime().addMSecs(std::numeric_limits<qint64>::max());
+        tmp_entry.reset();
+
+#ifndef QT_NO_DEBUG_OUTPUT
+        qDebug() << "Reset tmp_entry";
+#endif
+    }
+}
+
+#ifndef QT_NO_DEBUG_OUTPUT
+QDebug operator<<(QDebug dbg, const FreqHistory &history)
+{
+    QDebugStateSaver saver(dbg);
+    for (auto it = history.cache->cbegin(); it; it++)
+    {
+        dbg.nospace() << *it;
+    }
+    return dbg;
+}
+#endif

--- a/src/applications/gqrx/freqhistory.cpp
+++ b/src/applications/gqrx/freqhistory.cpp
@@ -65,6 +65,16 @@ bool FreqHistory::forward(FreqHistoryEntry &entry)
     return false;
 }
 
+bool FreqHistory::get_entry(int position, FreqHistoryEntry &entry)
+{
+    if (position >= 0)
+    {
+        entry = *cache->at(position);
+        return true;
+    }
+    return false;
+}
+
 bool FreqHistory::is_first() const
 {
     return cur_index <= 0;

--- a/src/applications/gqrx/freqhistory.cpp
+++ b/src/applications/gqrx/freqhistory.cpp
@@ -21,7 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "freqhistory.h"
+#include "applications/gqrx/freqhistory.h"
 
 FreqHistory::FreqHistory() :
     cache(new FHCache()),

--- a/src/applications/gqrx/freqhistory.cpp
+++ b/src/applications/gqrx/freqhistory.cpp
@@ -21,9 +21,11 @@
  * Boston, MA 02110-1301, USA.
  */
 
+#include <QTimer>
+
 #include "applications/gqrx/freqhistory.h"
 
-FreqHistory::FreqHistory() :
+FreqHistory::FreqHistory() : QObject(),
     cache(new FHCache()),
     tmp_entry_tstamp(QDateTime::currentDateTime().addMSecs(std::numeric_limits<qint64>::max())),
     cur_index(-1)
@@ -35,9 +37,16 @@ bool FreqHistory::back(FreqHistoryEntry &entry)
     store_tmp_entry();
     if (cur_index > 0)
     {
-        entry = *cache->at(--cur_index);
+        if (tmp_entry.isNull() || cache->at(cur_index)->equals(*tmp_entry, true))
+            entry = *cache->at(--cur_index);
+        else
+            entry = *cache->at(cur_index);
+        emit history_first(is_first());
+        emit history_last(is_last());
         return true;
     }
+    emit history_first(is_first());
+    emit history_last(is_last());
     return false;
 }
 
@@ -47,19 +56,23 @@ bool FreqHistory::forward(FreqHistoryEntry &entry)
     if (cache->count() > cur_index + 1)
     {
         entry = *cache->at(++cur_index);
+        emit history_first(is_first());
+        emit history_last(is_last());
         return true;
     }
+    emit history_first(is_first());
+    emit history_last(is_last());
     return false;
 }
 
-bool FreqHistory::is_first()
+bool FreqHistory::is_first() const
 {
     return cur_index <= 0;
 }
 
-bool FreqHistory::is_last()
+bool FreqHistory::is_last() const
 {
-    return cur_index < 0 || cur_index >= cache->count() - 1 || (tmp_entry && *cache->at(cur_index) != *tmp_entry);
+    return cur_index < 0 || cur_index >= cache->count() - 1;
 }
 
 int FreqHistory::position() const
@@ -84,26 +97,82 @@ int FreqHistory::timeout_ms() const
 
 void FreqHistory::try_make_entry(const FreqHistoryEntry &entry)
 {
-    store_tmp_entry();
-    tmp_entry_tstamp = QDateTime::currentDateTime().addMSecs(timeout_ms());
-    tmp_entry = FHCacheEntry(new FreqHistoryEntry(entry));
+    if (tmp_entry && tmp_entry->freq_hz == entry.freq_hz)
+    {
+        // update available tmp_entry before storing
+        if (*tmp_entry != entry)
+            *tmp_entry = entry;
 
 #ifndef QT_NO_DEBUG_OUTPUT
-    qDebug() << "Modified tmp_entry: " << tmp_entry->freq_hz;
+        qDebug() << "Modified tmp_entry: " << tmp_entry->freq_hz;
 #endif
+
+        store_tmp_entry();
+    }
+    else
+    {
+        store_tmp_entry();
+        tmp_entry_tstamp = QDateTime::currentDateTime().addMSecs(timeout_ms());
+        tmp_entry = FHCacheEntry(new FreqHistoryEntry(entry));
+
+#ifndef QT_NO_DEBUG_OUTPUT
+        qDebug() << "New tmp_entry: " << tmp_entry->freq_hz;
+#endif
+    }
+
+    // try to sync after the timeout (+ 20 to be sure after tmp_entry_tstamp)
+    QTimer::singleShot(timeout_ms() + 20, this, [=]() {
+        store_tmp_entry();
+    });
 }
 
-int FreqHistory::cache_size()
+void FreqHistory::set_offset_freq(qint64 freq_hz, qint64 offset_hz)
+{
+    set_member(freq_hz, FreqHistoryEntry::Varname::offset_freq_hz, offset_hz);
+}
+
+void FreqHistory::set_demod(qint64 freq_hz, DockRxOpt::rxopt_mode_idx demod)
+{
+    set_member(freq_hz, FreqHistoryEntry::Varname::demod, demod);
+}
+
+void FreqHistory::set_squelch(qint64 freq_hz, double db_level)
+{
+    set_member(freq_hz, FreqHistoryEntry::Varname::squelch, db_level);
+}
+
+void FreqHistory::set_filter(qint64 freq_hz, int filter)
+{
+    set_member(freq_hz, FreqHistoryEntry::Varname::filter, filter);
+}
+
+void FreqHistory::set_filter_freq(qint64 freq_hz, int min_hz, int max_hz)
+{
+    set_member(freq_hz, FreqHistoryEntry::Varname::min_hz, min_hz, FreqHistoryEntry::Varname::max_hz, max_hz);
+}
+
+void FreqHistory::set_filter_bw(qint64 freq_hz, int bandwidth)
+{
+    set_member(freq_hz, FreqHistoryEntry::Varname::filter_bw, bandwidth);
+}
+
+void FreqHistory::set_filter_shape(qint64 freq_hz, int shape)
+{
+    set_member(freq_hz, FreqHistoryEntry::Varname::filter_shape, shape);
+}
+
+int FreqHistory::cache_size() const
 {
     return FH_DEFAULT_SIZE;
 }
 
-void FreqHistory::cleanup()
+inline void FreqHistory::cleanup()
 {
     if (cache->empty())
         return;
 
     cache->resize(cur_index + 1);
+    emit_history_size_changed();
 }
 
 void FreqHistory::make_entry(const FHCacheEntry &entry)
@@ -117,10 +186,27 @@ void FreqHistory::make_entry(const FHCacheEntry &entry)
     qDebug() << "<<<";
 #endif
 
-    if (cur_index >= 0 && *cache->at(cur_index) == *entry)
-    {
-        // entry already available
-        return;
+    if (cur_index >= 0) {
+        if (*cache->at(cur_index) == *entry)
+        {
+            // entry already available
+            return;
+        }
+        else if (cache->at(cur_index)->equals(*entry, true))
+        {
+            // values for frequency changed
+            cache->replace(cur_index, entry);
+#ifndef QT_NO_DEBUG_OUTPUT
+            qDebug() << ">>> History [" << cache->count() << "] modified:";
+            for (auto i = 0; i < cache->count(); i++)
+            {
+                qDebug() << " " << (i < 10 ? " " : "") << i << " " << *cache->at(i);
+            }
+            qDebug() << "<<<";
+#endif
+            emit history_updated(cur_index, cache->count(), *entry);
+            return;
+        }
     }
 
     if (cache->count() >= cache_size())
@@ -128,6 +214,7 @@ void FreqHistory::make_entry(const FHCacheEntry &entry)
         // max. history cache size reached, remove first (oldest)
         cache->removeFirst();
         cur_index -= 1; /* should stay >= 0, but it's checked with cache_size in if block */
+        emit_history_size_changed();
     }
 
     cur_index++;
@@ -141,6 +228,7 @@ void FreqHistory::make_entry(const FHCacheEntry &entry)
     else
     {
         cache->append(entry);
+        emit_history_size_changed();
     }
 
 #ifndef QT_NO_DEBUG_OUTPUT
@@ -163,8 +251,49 @@ void FreqHistory::store_tmp_entry()
         tmp_entry.reset();
 
 #ifndef QT_NO_DEBUG_OUTPUT
+        Q_ASSERT(tmp_entry.isNull());
         qDebug() << "Reset tmp_entry";
 #endif
+    }
+}
+
+inline void FreqHistory::emit_history_size_changed()
+{
+    emit history_size_changed(cur_index, cache->count());
+    emit history_last(is_last());
+    emit history_first(is_first());
+}
+
+template<typename T>
+inline void FreqHistory::set_member(qint64 freq_hz, const FreqHistoryEntry::Varname varname, T value)
+{
+    if (tmp_entry && tmp_entry->freq_hz == freq_hz)
+    {
+        tmp_entry->set<T>(varname, value);
+    }
+    else if (cur_index >= 0 && cache->at(cur_index)->freq_hz == freq_hz)
+    {
+        FreqHistoryEntry entry(*cache->at(cur_index));
+        entry.set<T>(varname, value);
+        try_make_entry(entry);
+    }
+}
+
+template<typename T1, typename T2>
+inline void FreqHistory::set_member(qint64 freq_hz, const FreqHistoryEntry::Varname varname1, T1 value1,
+                             const FreqHistoryEntry::Varname varname2, T2 value2)
+{
+    if (tmp_entry && tmp_entry->freq_hz == freq_hz)
+    {
+        tmp_entry->set<T1>(varname1, value1);
+        tmp_entry->set<T2>(varname2, value2);
+    }
+    else if (cur_index >= 0 && cache->at(cur_index)->freq_hz == freq_hz)
+    {
+        FreqHistoryEntry entry(*cache->at(cur_index));
+        entry.set<T1>(varname1, value1);
+        entry.set<T2>(varname2, value2);
+        try_make_entry(entry);
     }
 }
 

--- a/src/applications/gqrx/freqhistory.cpp
+++ b/src/applications/gqrx/freqhistory.cpp
@@ -131,9 +131,7 @@ void FreqHistory::try_make_entry(const FreqHistoryEntry &entry)
     }
 
     // try to sync after the timeout (+ 20 to be sure after tmp_entry_tstamp)
-    QTimer::singleShot(timeout_ms() + 20, this, [=]() {
-        store_tmp_entry();
-    });
+    QTimer::singleShot(timeout_ms() + 20, this, SLOT(store_tmp_entry()));
 }
 
 void FreqHistory::set_offset_freq(qint64 freq_hz, qint64 offset_hz)

--- a/src/applications/gqrx/freqhistory.h
+++ b/src/applications/gqrx/freqhistory.h
@@ -64,6 +64,14 @@ public:
     bool forward(FreqHistoryEntry &entry);
 
     /**
+     * @brief Retrieves entry at cache position
+     * @param position
+     * @param entry
+     * @return true if entry found and filled
+     */
+    bool get_entry(int position, FreqHistoryEntry &entry);
+
+    /**
      * @brief currently on first position
      * @return
      */

--- a/src/applications/gqrx/freqhistory.h
+++ b/src/applications/gqrx/freqhistory.h
@@ -1,0 +1,144 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Markus Kolb
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef FREQHISTORY_H
+#define FREQHISTORY_H
+
+#include <QDateTime>
+#include <QScopedPointer>
+#include <QSharedPointer>
+#include <QVector>
+
+#include "freqhistoryentry.h"
+
+#define FH_DEFAULT_SIZE 20              /* the max. number of entries cached by default */
+#define FH_DEFAULT_TIMEOUT_MS 2000      /* timeout in ms need to elapse for history */
+
+typedef QSharedPointer<FreqHistoryEntry> FHCacheEntry;
+typedef QVector<FHCacheEntry> FHCache;
+
+/**
+ * @brief FreqHistory caches frequency settings for fast jump back/forward in history
+ *
+ * The newest FH_DEFAULT_SIZE entries are cached in history.
+ * Storing values in history happens after delay of FH_DEFAULT_TIMEOUT_MS ms.
+ */
+class FreqHistory
+{
+public:
+    FreqHistory();
+    /**
+     * @brief Go back in history and retrieve the entry
+     * @param entry
+     * @return true if entry param set
+     */
+    bool back(FreqHistoryEntry &entry);
+
+    /**
+     * @brief Go forward after moving back in history and retrieve the newer entry
+     * @param entry
+     * @return true if entry param set
+     */
+    bool forward(FreqHistoryEntry &entry);
+
+    /**
+     * @brief currently on first position
+     * @return
+     */
+    bool is_first();
+
+    /**
+     * @brief currently on last position
+     * @return
+     */
+    bool is_last();
+
+    /**
+     * @brief Get current position in history
+     * @return
+     */
+    int position() const;
+
+    /**
+     * @brief Get history size
+     * @return
+     */
+    int size() const;
+
+    /**
+     * @brief Bring in sync any delayed history additions
+     */
+    void sync();
+
+    /**
+     * @brief Get timeout in ms when frequencies without change are added
+     * @return
+     */
+    int timeout_ms() const;
+
+    /**
+     * @brief Make a new entry in history. This will become the current and also newest entry in history.
+     * But not before time FH_DEFAULT_TIMEOUT_MS after this call has finished.
+     * @param entry
+     */
+    void try_make_entry(const FreqHistoryEntry &entry);
+
+#ifndef QT_NO_DEBUG_OUTPUT
+    friend QDebug operator<<(QDebug dbg, const FreqHistory &history);
+#endif
+
+protected:
+    int cache_size();
+
+private:
+    /**
+     * @brief cleanup the cache up to one entry back in history
+     */
+    void cleanup();
+
+    /**
+     * @brief Handles adding entries
+     * @param entry
+     */
+    void make_entry(const FHCacheEntry &entry);
+
+    /**
+     * @brief store tmp_entry permanent
+     */
+    void store_tmp_entry();
+
+    /**
+     * @brief storage for history caching
+     */
+    const QScopedPointer<FHCache> cache;
+
+    /**
+     * @brief temporary storage to try making new entry with handling timeout
+     */
+    FHCacheEntry tmp_entry;
+    QDateTime tmp_entry_tstamp;
+
+    int cur_index;
+};
+
+
+#endif // FREQHISTORY_H

--- a/src/applications/gqrx/freqhistory.h
+++ b/src/applications/gqrx/freqhistory.h
@@ -188,11 +188,6 @@ private:
     void make_entry(const FHCacheEntry &entry);
 
     /**
-     * @brief store tmp_entry permanent
-     */
-    void store_tmp_entry();
-
-    /**
      * @brief emits signales related to history size changes
      */
     inline void emit_history_size_changed();
@@ -209,6 +204,13 @@ private:
      */
     const QScopedPointer<FHCache> cache;
 
+private slots:
+    /**
+     * @brief store tmp_entry permanent
+     */
+    void store_tmp_entry();
+
+private:
     /**
      * @brief temporary storage to try making new entry with handling timeout
      */

--- a/src/applications/gqrx/freqhistory.h
+++ b/src/applications/gqrx/freqhistory.h
@@ -28,7 +28,7 @@
 #include <QSharedPointer>
 #include <QVector>
 
-#include "freqhistoryentry.h"
+#include "applications/gqrx/freqhistoryentry.h"
 
 #define FH_DEFAULT_SIZE 20              /* the max. number of entries cached by default */
 #define FH_DEFAULT_TIMEOUT_MS 2000      /* timeout in ms need to elapse for history */

--- a/src/applications/gqrx/freqhistoryentry.cpp
+++ b/src/applications/gqrx/freqhistoryentry.cpp
@@ -38,14 +38,30 @@ FreqHistoryEntry &FreqHistoryEntry::operator=(const FreqHistoryEntry &entry)
     return *this;
 }
 
-bool FreqHistoryEntry::operator==(const FreqHistoryEntry &entry)
+bool FreqHistoryEntry::operator==(const FreqHistoryEntry &entry) const
 {
-    return (freq_hz == entry.freq_hz);
+    return (freq_hz == entry.freq_hz && demod == entry.demod &&
+            max_hz == entry.max_hz && min_hz == entry.min_hz &&
+            squelch == entry.squelch && offset_freq_hz == entry.offset_freq_hz &&
+            filter == entry.filter &&
+            filter_bw == entry.filter_bw && filter_shape == entry.filter_shape);
 }
 
-bool FreqHistoryEntry::operator!=(const FreqHistoryEntry &entry)
+bool FreqHistoryEntry::operator!=(const FreqHistoryEntry &entry) const
 {
     return !(*this == entry);
+}
+
+bool FreqHistoryEntry::equals(const FreqHistoryEntry &entry, bool only_freq) const
+{
+    if (only_freq)
+    {
+        return freq_hz == entry.freq_hz;
+    }
+    else
+    {
+        return *this == entry;
+    }
 }
 
 void FreqHistoryEntry::assign(const FreqHistoryEntry &entry)
@@ -55,6 +71,7 @@ void FreqHistoryEntry::assign(const FreqHistoryEntry &entry)
     min_hz = entry.min_hz;
     freq_hz = entry.freq_hz;
     squelch = entry.squelch;
+    filter = entry.filter;
     filter_bw = entry.filter_bw;
     filter_shape = entry.filter_shape;
     offset_freq_hz = entry.offset_freq_hz;

--- a/src/applications/gqrx/freqhistoryentry.cpp
+++ b/src/applications/gqrx/freqhistoryentry.cpp
@@ -1,0 +1,70 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Markus Kolb
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "freqhistoryentry.h"
+
+FreqHistoryEntry::FreqHistoryEntry()
+{
+}
+
+FreqHistoryEntry::FreqHistoryEntry(const FreqHistoryEntry &entry)
+{
+    assign(entry);
+}
+
+FreqHistoryEntry &FreqHistoryEntry::operator=(const FreqHistoryEntry &entry)
+{
+    assign(entry);
+    return *this;
+}
+
+bool FreqHistoryEntry::operator==(const FreqHistoryEntry &entry)
+{
+    return (freq_hz == entry.freq_hz);
+}
+
+bool FreqHistoryEntry::operator!=(const FreqHistoryEntry &entry)
+{
+    return !(*this == entry);
+}
+
+void FreqHistoryEntry::assign(const FreqHistoryEntry &entry)
+{
+    demod = entry.demod;
+    max_hz = entry.max_hz;
+    min_hz = entry.min_hz;
+    freq_hz = entry.freq_hz;
+    squelch = entry.squelch;
+    filter_bw = entry.filter_bw;
+    filter_shape = entry.filter_shape;
+    offset_freq_hz = entry.offset_freq_hz;
+}
+
+#ifndef QT_NO_DEBUG_OUTPUT
+QDebug operator<<(QDebug dbg, const FreqHistoryEntry &entry)
+{
+    QDebugStateSaver saver(dbg);
+    dbg.nospace() << "freq_hz: " << entry.freq_hz;
+    return dbg;
+}
+#endif

--- a/src/applications/gqrx/freqhistoryentry.cpp
+++ b/src/applications/gqrx/freqhistoryentry.cpp
@@ -21,7 +21,7 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#include "freqhistoryentry.h"
+#include "applications/gqrx/freqhistoryentry.h"
 
 FreqHistoryEntry::FreqHistoryEntry()
 {

--- a/src/applications/gqrx/freqhistoryentry.h
+++ b/src/applications/gqrx/freqhistoryentry.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Markus Kolb
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef FREQHISTORYENTRY_H
+#define FREQHISTORYENTRY_H
+
+#ifndef QT_NO_DEBUG_OUTPUT
+#include <QtDebug>
+#endif
+#include <QtGlobal>
+
+#include "qtgui/dockrxopt.h"
+
+class FreqHistoryEntry
+{
+public:
+    FreqHistoryEntry();
+    FreqHistoryEntry(const FreqHistoryEntry &entry);
+    FreqHistoryEntry &operator=(const FreqHistoryEntry &entry);
+    bool operator==(const FreqHistoryEntry &entry);
+    bool operator!=(const FreqHistoryEntry &entry);
+
+    DockRxOpt::rxopt_mode_idx demod;
+    qint64 filter_bw;
+    int filter_shape;
+    qint64 freq_hz;
+    qint64 min_hz, max_hz;
+    qint64 offset_freq_hz;
+    double squelch;
+
+protected:
+    void assign(const FreqHistoryEntry &entry);
+};
+
+#ifndef QT_NO_DEBUG_OUTPUT
+QDebug operator<<(QDebug dbg, const FreqHistoryEntry &entry);
+#endif
+
+#endif // FREQHISTORYENTRY_H

--- a/src/applications/gqrx/freqhistoryentry.h
+++ b/src/applications/gqrx/freqhistoryentry.h
@@ -36,14 +36,58 @@ public:
     FreqHistoryEntry();
     FreqHistoryEntry(const FreqHistoryEntry &entry);
     FreqHistoryEntry &operator=(const FreqHistoryEntry &entry);
-    bool operator==(const FreqHistoryEntry &entry);
-    bool operator!=(const FreqHistoryEntry &entry);
+    bool operator==(const FreqHistoryEntry &entry) const;
+    bool operator!=(const FreqHistoryEntry &entry) const;
+    bool equals(const FreqHistoryEntry &entry, bool only_freq) const;
+
+    enum class Varname {
+        demod, max_hz, min_hz, freq_hz, squelch, filter,
+        filter_bw, filter_shape, offset_freq_hz
+    };
+
+    template<typename T>
+    void set(const Varname varname, T value)
+    {
+        switch (varname) {
+        case Varname::demod:
+            demod = static_cast<DockRxOpt::rxopt_mode_idx>(value);
+            break;
+        case Varname::max_hz:
+            max_hz = value;
+            break;
+        case Varname::min_hz:
+            min_hz = value;
+            break;
+        case Varname::freq_hz:
+            freq_hz = value;
+            break;
+        case Varname::squelch:
+            squelch = value;
+            break;
+        case Varname::filter:
+            filter = value;
+            break;
+        case Varname::filter_bw:
+            filter_bw = value;
+            break;
+        case Varname::filter_shape:
+            filter_shape = value;
+            break;
+        case Varname::offset_freq_hz:
+            offset_freq_hz = value;
+            break;
+        default:
+            throw "FreqHistoryEntry::set(...) varname not implemented";
+            break;
+        }
+    }
 
     DockRxOpt::rxopt_mode_idx demod;
+    int filter;
     qint64 filter_bw;
     int filter_shape;
     qint64 freq_hz;
-    qint64 min_hz, max_hz;
+    int min_hz, max_hz;
     qint64 offset_freq_hz;
     double squelch;
 

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -266,15 +266,15 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(&freq_history, &FreqHistory::history_first, this, &MainWindow::on_FHFirst);
     connect(&freq_history, &FreqHistory::history_last, this, &MainWindow::on_FHLast);
     connect(ui->freqCtrl, SIGNAL(newFrequency(qint64)), this, SLOT(setFHFrequency(qint64)));
-    connect(uiDockRxOpt, SIGNAL(rxFreqChanged(qint64)), ui->freqCtrl, SLOT(setFHFrequency(qint64)));
+    connect(uiDockRxOpt, SIGNAL(rxFreqChanged(qint64)), this, SLOT(setFHFrequency(qint64)));
     connect(uiDockRxOpt, SIGNAL(filterOffsetChanged(qint64)), this, SLOT(setFHFreqOffset(qint64)));
     connect(uiDockRxOpt, SIGNAL(demodSelected(int)), this, SLOT(setFHDemod(int)));
     connect(uiDockRxOpt, SIGNAL(sqlLevelChanged(double)), this, SLOT(setFHSquelch(double)));
-    connect(remote, SIGNAL(newFrequency(qint64)), ui->freqCtrl, SLOT(setFHFrequency(qint64)));
+    connect(remote, SIGNAL(newFrequency(qint64)), this, SLOT(setFHFrequency(qint64)));
     connect(remote, SIGNAL(newFilterOffset(qint64)), this, SLOT(setFHFreqOffset(qint64)));
     connect(remote, SIGNAL(newMode(int)), this, SLOT(setFHDemod(int)));
     connect(remote, SIGNAL(newSquelchLevel(double)), this, SLOT(setFHSquelch(double)));
-    connect(ui->plotter, SIGNAL(newFilterFreq(int, int)), remote, SLOT(setFHFilterFreq(int, int)));
+    connect(ui->plotter, SIGNAL(newFilterFreq(int, int)), this, SLOT(setFHFilterFreq(int, int)));
     connect(remote, SIGNAL(newPassband(int)), this, SLOT(setFHFilterBand(int)));
 
     // I/Q playback

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -50,7 +50,7 @@
 #include "applications/gqrx/receiver.h"
 #endif
 
-#include "freqhistory.h"
+#include "applications/gqrx/freqhistory.h"
 
 namespace Ui {
     class MainWindow;  /*! The main window UI */

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -50,6 +50,8 @@
 #include "applications/gqrx/receiver.h"
 #endif
 
+#include "freqhistory.h"
+
 namespace Ui {
     class MainWindow;  /*! The main window UI */
 }
@@ -70,6 +72,7 @@ public:
 
 public slots:
     void setNewFrequency(qint64 rx_freq);
+    void makeFreqHistory(qint64 rx_freq);
 
 private:
     Ui::MainWindow *ui;
@@ -118,6 +121,8 @@ private:
     RemoteControl *remote;
 
     std::map<QString, QVariant> devList;
+
+    FreqHistory freq_history;
 
     // dummy widget to enforce linking to QtSvg
     QSvgWidget      *qsvg_dummy;
@@ -238,6 +243,11 @@ private slots:
     void iqFftTimeout();
     void audioFftTimeout();
     void rdsTimeout();
+
+    /* frequency history */
+    void on_actionFrequencyBack_triggered();
+    void on_actionFrequencyForward_triggered();
+    void on_fqHistoryTimeout();
 };
 
 #endif // MAINWINDOW_H

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -133,6 +133,7 @@ private:
     void showSimpleTextFile(const QString &resource_path,
                             const QString &window_title);
     inline void getBandwidthLimits(int bandwidth, int *lo, int *hi);
+    inline void activateFHFreq(const FreqHistoryEntry &fq_entry);
 
 private slots:
     /* RecentConfig */

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -72,7 +72,6 @@ public:
 
 public slots:
     void setNewFrequency(qint64 rx_freq);
-    void makeFreqHistory(qint64 rx_freq);
 
 private:
     Ui::MainWindow *ui;
@@ -133,6 +132,7 @@ private:
     void updateGainStages(bool read_from_device);
     void showSimpleTextFile(const QString &resource_path,
                             const QString &window_title);
+    inline void getBandwidthLimits(int bandwidth, int *lo, int *hi);
 
 private slots:
     /* RecentConfig */
@@ -231,7 +231,8 @@ private slots:
     void on_actionAbout_triggered();
     void on_actionAboutQt_triggered();
     void on_actionAddBookmark_triggered();
-
+    void on_actionFHBack_triggered();
+    void on_actionFHForward_triggered();
 
     /* window close signals */
     void afsk1200win_closed();
@@ -245,9 +246,14 @@ private slots:
     void rdsTimeout();
 
     /* frequency history */
-    void on_actionFrequencyBack_triggered();
-    void on_actionFrequencyForward_triggered();
-    void on_fqHistoryTimeout();
+    void setFHFrequency(qint64 freq_hz);
+    void setFHFreqOffset(qint64 freq_hz);
+    void setFHDemod(int index);
+    void setFHSquelch(double db_level);
+    void setFHFilterFreq(int low, int high);
+    void setFHFilterBand(int bandwidth);
+    void on_FHFirst(bool is_first);
+    void on_FHLast(bool is_last);
 };
 
 #endif // MAINWINDOW_H

--- a/src/applications/gqrx/mainwindow.ui
+++ b/src/applications/gqrx/mainwindow.ui
@@ -246,8 +246,8 @@
     <addaction name="actionRemoteConfig"/>
     <addaction name="separator"/>
     <addaction name="actionAddBookmark"/>
-    <addaction name="actionFrequencyBack"/>
-    <addaction name="actionFrequencyForward"/>
+    <addaction name="actionFHBack"/>
+    <addaction name="actionFHForward"/>
     <addaction name="separator"/>
     <addaction name="actionIqTool"/>
     <addaction name="separator"/>
@@ -276,8 +276,8 @@
    <addaction name="actionSaveSettings"/>
    <addaction name="separator"/>
    <addaction name="actionAddBookmark"/>
-   <addaction name="actionFrequencyBack"/>
-   <addaction name="actionFrequencyForward"/>
+   <addaction name="actionFHBack"/>
+   <addaction name="actionFHForward"/>
    <addaction name="separator"/>
    <addaction name="actionIqTool"/>
    <addaction name="separator"/>
@@ -554,7 +554,7 @@
     <string>Ctrl+W</string>
    </property>
   </action>
-  <action name="actionFrequencyBack">
+  <action name="actionFHBack">
    <property name="icon">
     <iconset resource="../../../resources/icons.qrc">
      <normaloff>:/icons/icons/backward.svg</normaloff>:/icons/icons/backward.svg</iconset>
@@ -569,7 +569,7 @@
     <string>Ctrl+Shift+Left</string>
    </property>
   </action>
-  <action name="actionFrequencyForward">
+  <action name="actionFHForward">
    <property name="icon">
     <iconset resource="../../../resources/icons.qrc">
      <normaloff>:/icons/icons/forward.svg</normaloff>:/icons/icons/forward.svg</iconset>

--- a/src/applications/gqrx/mainwindow.ui
+++ b/src/applications/gqrx/mainwindow.ui
@@ -246,6 +246,8 @@
     <addaction name="actionRemoteConfig"/>
     <addaction name="separator"/>
     <addaction name="actionAddBookmark"/>
+    <addaction name="actionFrequencyBack"/>
+    <addaction name="actionFrequencyForward"/>
     <addaction name="separator"/>
     <addaction name="actionIqTool"/>
     <addaction name="separator"/>
@@ -274,6 +276,8 @@
    <addaction name="actionSaveSettings"/>
    <addaction name="separator"/>
    <addaction name="actionAddBookmark"/>
+   <addaction name="actionFrequencyBack"/>
+   <addaction name="actionFrequencyForward"/>
    <addaction name="separator"/>
    <addaction name="actionIqTool"/>
    <addaction name="separator"/>
@@ -548,6 +552,36 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+W</string>
+   </property>
+  </action>
+  <action name="actionFrequencyBack">
+   <property name="icon">
+    <iconset resource="../../../resources/icons.qrc">
+     <normaloff>:/icons/icons/backward.svg</normaloff>:/icons/icons/backward.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Frequency History Backwards</string>
+   </property>
+   <property name="toolTip">
+    <string>Go to previous frequency (Ctrl+Shift+Left)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Left</string>
+   </property>
+  </action>
+  <action name="actionFrequencyForward">
+   <property name="icon">
+    <iconset resource="../../../resources/icons.qrc">
+     <normaloff>:/icons/icons/forward.svg</normaloff>:/icons/icons/forward.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Frequency History Forwards</string>
+   </property>
+   <property name="toolTip">
+    <string>Go to next frequency (Ctrl+Shift+Right)</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+Right</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
In https://github.com/csete/gqrx/issues/764 I have announced my development of a FrequencyHistory feature to go back and forward on frequency selections and receiver settings to this frequency.

Entries are added to history after 2 seconds without change.
There is a maximum of 20 entries. Older one is removed.

There are two new buttons in menubar and two entries in tools menu.

Next to frequency the filter settings, mode and squelch setting are restored.

![freq-history](https://user-images.githubusercontent.com/5228369/75885201-638a5600-5e26-11ea-89c9-d025dd739950.png)
