### PR TITLE
Feature to provide menu for recent config files

### DIFF
--- a/gqrx.pro
+++ b/gqrx.pro
@@ -96,6 +96,7 @@ SOURCES += \
     src/applications/gqrx/mainwindow.cpp \
     src/applications/gqrx/receiver.cpp \
     src/applications/gqrx/file_resources.cpp \
+    src/applications/gqrx/recentconfig.cpp \
     src/applications/gqrx/remote_control.cpp \
     src/applications/gqrx/remote_control_settings.cpp \
     src/dsp/afsk1200/cafsk12.cpp \
@@ -149,6 +150,7 @@ HEADERS += \
     src/applications/gqrx/gqrx.h \
     src/applications/gqrx/mainwindow.h \
     src/applications/gqrx/receiver.h \
+    src/applications/gqrx/recentconfig.h \
     src/applications/gqrx/remote_control.h \
     src/applications/gqrx/remote_control_settings.h \
     src/dsp/afsk1200/cafsk12.h \

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Start/stop DSP via remote control.
        NEW: Device scan button in Configure I/O devices dialog.
+       NEW: Added "Recent settings" menu.
 
 
     2.13.5: Released November 7, 2020

--- a/src/applications/CMakeLists.txt
+++ b/src/applications/CMakeLists.txt
@@ -11,6 +11,8 @@ add_source_files(SRCS_LIST
 	gqrx/remote_control_settings.h
 	gqrx/remote_control.cpp
 	gqrx/remote_control.h
+	gqrx/recentconfig.cpp
+	gqrx/recentconfig.h
 	gqrx/file_resources.cpp
 )
 

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -301,7 +301,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     CIoConfig::getDeviceList(devList);
 
     m_recent_config = new RecentConfig(m_cfg_dir, ui->menu_RecentConfig);
-    connect(m_recent_config.data(), SIGNAL(loadConfig(const QString &)), this, SLOT(loadConfigSlot(const QString &)));
+    connect(m_recent_config, SIGNAL(loadConfig(const QString &)), this, SLOT(loadConfigSlot(const QString &)));
 
     // restore last session
     if (!loadConfig(cfgfile, true, true))
@@ -374,7 +374,6 @@ MainWindow::~MainWindow()
         delete m_settings;
     }
 
-    m_recent_config.clear();
     delete m_recent_config;
 
     delete iq_tool;

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -77,7 +77,7 @@ private:
     QPointer<QSettings> m_settings;  /*!< Application wide settings. */
     QString             m_cfg_dir;   /*!< Default config dir, e.g. XDG_CONFIG_HOME. */
     QString             m_last_dir;
-    QPointer<RecentConfig> m_recent_config; /* Menu File Recent config */
+    RecentConfig       *m_recent_config; /* Menu File Recent config */
 
     qint64 d_lnb_lo;  /* LNB LO in Hz. */
     qint64 d_hw_freq;

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -42,6 +42,7 @@
 #include "qtgui/afsk1200win.h"
 #include "qtgui/iq_tool.h"
 
+#include "applications/gqrx/recentconfig.h"
 #include "applications/gqrx/remote_control.h"
 
 // see https://bugreports.qt-project.org/browse/QTBUG-22829
@@ -76,6 +77,7 @@ private:
     QPointer<QSettings> m_settings;  /*!< Application wide settings. */
     QString             m_cfg_dir;   /*!< Default config dir, e.g. XDG_CONFIG_HOME. */
     QString             m_last_dir;
+    QPointer<RecentConfig> m_recent_config; /* Menu File Recent config */
 
     qint64 d_lnb_lo;  /* LNB LO in Hz. */
     qint64 d_hw_freq;
@@ -128,6 +130,9 @@ private:
                             const QString &window_title);
 
 private slots:
+    /* RecentConfig */
+    void loadConfigSlot(const QString &cfgfile);
+
     /* rf */
     void setLnbLo(double freq_mhz);
     void setAntenna(const QString antenna);

--- a/src/applications/gqrx/mainwindow.ui
+++ b/src/applications/gqrx/mainwindow.ui
@@ -195,18 +195,27 @@
      <x>0</x>
      <y>0</y>
      <width>521</width>
-     <height>19</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menu_RecentConfig">
+     <property name="toolTip">
+      <string>Load recently used setting</string>
+     </property>
+     <property name="title">
+      <string>&amp;Recent settings</string>
+     </property>
+    </widget>
     <addaction name="actionDSP"/>
     <addaction name="separator"/>
     <addaction name="actionIoConfig"/>
     <addaction name="actionLoadSettings"/>
     <addaction name="actionSaveSettings"/>
+    <addaction name="menu_RecentConfig"/>
     <addaction name="separator"/>
     <addaction name="actionSaveWaterfall"/>
     <addaction name="separator"/>

--- a/src/applications/gqrx/recentconfig.cpp
+++ b/src/applications/gqrx/recentconfig.cpp
@@ -38,16 +38,7 @@ RecentConfig::RecentConfig(const QString &configDir, QMenu *menu) : QObject()
 
     configFile = QFileInfo(QDir(configDir), RECENT_CONFIG_FILENAME);
 
-#ifndef QT_NO_DEBUG_OUTPUT
-    if (loadRecentConfig())
-        qDebug() << "Read file " << configFile.canonicalFilePath();
-    else if (configFile.canonicalFilePath().isEmpty())
-        qDebug() << "No file " << configFile.absoluteFilePath();
-    else
-        qDebug() << "Read failed of file " << configFile.absoluteFilePath();
-#else
     loadRecentConfig();
-#endif
 
     connect(this, &RecentConfig::configLoaded, this, &RecentConfig::onConfigLoaded);
     connect(this, &RecentConfig::configSaved, this, &RecentConfig::onConfigSaved);
@@ -55,14 +46,7 @@ RecentConfig::RecentConfig(const QString &configDir, QMenu *menu) : QObject()
 
 RecentConfig::~RecentConfig()
 {
-#ifndef QT_NO_DEBUG_OUTPUT
-    if (saveRecentConfig())
-        qDebug() << "Written file " << configFile.absoluteFilePath();
-    else
-        qDebug() << "Write failed to file " << configFile.absoluteFilePath();
-#else
     saveRecentConfig();
-#endif
 }
 
 void RecentConfig::createMenuActions()
@@ -186,8 +170,5 @@ void RecentConfig::onMenuAction(int index) const
     {
         const auto fname = cfgfiles->at(index).canonicalFilePath();
         emit loadConfig(fname);
-#ifndef QT_NO_DEBUG_OUTPUT
-        qDebug() << "Emitted loadConfig(" << fname << ")";
-#endif
     }
 }

--- a/src/applications/gqrx/recentconfig.cpp
+++ b/src/applications/gqrx/recentconfig.cpp
@@ -1,0 +1,211 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Markus Kolb.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include <QDebug>
+#include <QDir>
+#include <QTextStream>
+
+#include "recentconfig.h"
+
+#define MENU_FILENAME_LEN 15
+// MENU_MAX_ENTRIES is limited by action shortcut numbering
+#define MENU_MAX_ENTRIES 9
+
+RecentConfig::RecentConfig(const QString &configDir, QMenu *menu) : QObject()
+{
+    this->menu = menu;
+    cfgfiles = QSharedPointer<QVector<QFileInfo>>(new QVector<QFileInfo>());
+
+    configFile = QFileInfo(QDir(configDir), RECENT_CONFIG_FILENAME);
+
+#ifndef QT_NO_DEBUG_OUTPUT
+    if (loadRecentConfig())
+        qDebug() << "Read file " << configFile.canonicalFilePath();
+    else if (configFile.canonicalFilePath().isEmpty())
+        qDebug() << "No file " << configFile.absoluteFilePath();
+    else
+        qDebug() << "Read failed of file " << configFile.absoluteFilePath();
+#else
+    loadRecentConfig();
+#endif
+
+    connect(this, &RecentConfig::configLoaded, this, &RecentConfig::onConfigLoaded);
+    connect(this, &RecentConfig::configSaved, this, &RecentConfig::onConfigSaved);
+}
+
+RecentConfig::~RecentConfig()
+{
+#ifndef QT_NO_DEBUG_OUTPUT
+    if (saveRecentConfig())
+        qDebug() << "Written file " << configFile.absoluteFilePath();
+    else
+        qDebug() << "Write failed to file " << configFile.absoluteFilePath();
+#else
+    saveRecentConfig();
+#endif
+}
+
+void RecentConfig::createMenuActions()
+{
+    menu->clear();
+    for (int i = 0; i < cfgfiles->count(); i++) {
+        const QFileInfo *file = &cfgfiles->at(i);
+        if (!file->exists())
+        {
+            cfgfiles->remove(i--);
+            continue;
+        }
+
+        QString fname(file->fileName());
+
+        QString nr = (i < 9 ? " &" : "&") + QString::number(i + 1);
+
+        // QAction deleted by clear above
+        QAction *action = new QAction(nr + " " + (fname.length() > MENU_FILENAME_LEN ?
+                                                      fname.left(MENU_FILENAME_LEN) + "..." : fname),
+                                      menu);
+        action->setStatusTip("Load settings from config file " + file->canonicalFilePath());
+        action->setData(i);
+        connect(action, &QAction::triggered, this, [=](bool) { onMenuAction(i); });
+        menu->addAction(action);
+    }
+}
+
+QVector<QFileInfo>::const_iterator RecentConfig::getConfigFiles() const
+{
+    return cfgfiles->cbegin();
+}
+
+QMenu *RecentConfig::getMenu()
+{
+    return menu;
+}
+
+bool RecentConfig::loadRecentConfig()
+{
+    QFile file(configFile.canonicalFilePath());
+
+    if (!file.open(QFile::ReadOnly))
+        return false;
+
+    QTextStream s(&file);
+
+    while (!s.atEnd())
+    {
+        QString buf;
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
+        if (!s.readLineInto(&buf, 33000))
+        {
+            file.close();
+            cfgfiles->clear();
+            return false;
+        }
+#else
+        buf = s.readLine(33000);
+        if (buf.isNull())
+        {
+            file.close();
+            cfgfiles->clear();
+            return false;
+        }
+#endif
+        if (!buf.isEmpty())
+        {
+            const auto fi = QFileInfo(buf);
+            if (fi.exists())
+                cfgfiles->append(fi);
+        }
+    }
+
+    file.close();
+    return true;
+}
+
+bool RecentConfig::saveRecentConfig()
+{
+    if (cfgfiles->count() == 0)
+    {
+        return false;
+    }
+
+    QFile file(configFile.absoluteFilePath());
+
+    if (!file.open(QFile::WriteOnly))
+        return false;
+
+    QTextStream s(&file);
+
+    for (auto it = cfgfiles->cbegin(); it != cfgfiles->cend(); it++)
+    {
+        s << it->canonicalFilePath() << "\n";
+    }
+
+    file.close();
+    return true;
+}
+
+void RecentConfig::onConfigSaved(const QString &filename)
+{
+    updateFiles(filename);
+    createMenuActions();
+}
+
+void RecentConfig::onConfigLoaded(const QString &filename)
+{
+    updateFiles(filename);
+    createMenuActions();
+}
+
+inline void RecentConfig::updateFiles(const QString &filename)
+{
+    QFileInfo file(filename);
+    if (!file.exists())
+        return;
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
+    cfgfiles->removeOne(file);
+#else
+    const int i = cfgfiles->indexOf(file);
+    if (i >= 0)
+    {
+        cfgfiles->removeAt(i);
+    }
+#endif
+    cfgfiles->prepend(file);
+    if (cfgfiles->count() > MENU_MAX_ENTRIES)
+    {
+        cfgfiles->removeLast();
+    }
+}
+
+void RecentConfig::onMenuAction(int index) const
+{
+    if (cfgfiles->count() > index)
+    {
+        const auto fname = cfgfiles->at(index).canonicalFilePath();
+        emit loadConfig(fname);
+#ifndef QT_NO_DEBUG_OUTPUT
+        qDebug() << "Emitted loadConfig(" << fname << ")";
+#endif
+    }
+}

--- a/src/applications/gqrx/recentconfig.cpp
+++ b/src/applications/gqrx/recentconfig.cpp
@@ -113,22 +113,12 @@ bool RecentConfig::loadRecentConfig()
     while (!s.atEnd())
     {
         QString buf;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
         if (!s.readLineInto(&buf, 33000))
         {
             file.close();
             cfgfiles->clear();
             return false;
         }
-#else
-        buf = s.readLine(33000);
-        if (buf.isNull())
-        {
-            file.close();
-            cfgfiles->clear();
-            return false;
-        }
-#endif
         if (!buf.isEmpty())
         {
             const auto fi = QFileInfo(buf);
@@ -182,15 +172,7 @@ inline void RecentConfig::updateFiles(const QString &filename)
     if (!file.exists())
         return;
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
     cfgfiles->removeOne(file);
-#else
-    const int i = cfgfiles->indexOf(file);
-    if (i >= 0)
-    {
-        cfgfiles->removeAt(i);
-    }
-#endif
     cfgfiles->prepend(file);
     if (cfgfiles->count() > MENU_MAX_ENTRIES)
     {

--- a/src/applications/gqrx/recentconfig.h
+++ b/src/applications/gqrx/recentconfig.h
@@ -1,0 +1,85 @@
+/* -*- c++ -*- */
+/*
+ * Gqrx SDR: Software defined radio receiver powered by GNU Radio and Qt
+ *           http://gqrx.dk/
+ *
+ * Copyright 2020 Markus Kolb.
+ *
+ * Gqrx is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ *
+ * Gqrx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Gqrx; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+#ifndef RECENTCONFIG_H
+#define RECENTCONFIG_H
+
+#include <QFileInfo>
+#include <QMenu>
+#include <QSharedPointer>
+
+#define RECENT_CONFIG_FILENAME "recentconfig.cfg"
+
+class RecentConfig : public QObject
+{
+    Q_OBJECT
+
+public:
+    RecentConfig(const QString &configDir, QMenu *menu);
+    ~RecentConfig();
+
+    /**
+     * @brief Create actions in menu for recent config files
+     */
+    void createMenuActions();
+
+signals:
+    /**
+     * @brief Connect to loadConfig and load the file
+     * @param filename
+     */
+    void loadConfig(const QString &filename) const;
+
+    /**
+     * @brief configSaved emit starts menu update for filename on save
+     * @param filename
+     */
+    void configSaved(const QString &filename);
+
+    /**
+     * @brief configLoaded emit starts menu update for filename on load
+     * @param filename
+     */
+    void configLoaded(const QString &filename);
+
+protected:
+    QVector<QFileInfo>::const_iterator getConfigFiles() const;
+    QMenu *getMenu();
+    bool loadRecentConfig();
+    bool saveRecentConfig();
+
+protected slots:
+    void onConfigSaved(const QString &filename);
+    void onConfigLoaded(const QString &filename);
+
+private:
+    QSharedPointer<QVector<QFileInfo>> cfgfiles;
+    QMenu *menu;
+    QFileInfo configFile;
+    inline void updateFiles(const QString &filename);
+
+private slots:
+    void onMenuAction(int index) const;
+
+};
+
+#endif // RECENTCONFIG_H


### PR DESCRIPTION
This stores the last used conf files in a new config file recentconfig.cfg in the default cfg directory.
In file menu there is a new sub-menu **Recent settings** (menu_RecentConfig).
There are added up to 9 actions to load the last known configurations.

![gqrx-recentconfig](https://user-images.githubusercontent.com/5228369/75981382-add20c80-5ee4-11ea-8568-22310a60b46e.png)
