### PR TITLE
Feature Device scan for IOConfig

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
       2.14: In progress...
 
        NEW: Start/stop DSP via remote control.
+       NEW: Device scan button in Configure I/O devices dialog.
 
 
     2.13.5: Released November 7, 2020

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -518,7 +518,17 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
     }
 
     QString outdev = m_settings->value("output/device", "").toString();
-    rx->set_output_device(outdev.toStdString());
+
+    try {
+        rx->set_output_device(outdev.toStdString());
+    } catch (std::exception &x) {
+        QMessageBox::warning(nullptr,
+                         QObject::tr("Failed to set output device"),
+                         QObject::tr("<p><b>%1</b></p>"
+                                     "Please select another device.")
+                                 .arg(x.what()),
+                         QMessageBox::Ok);
+    }
 
     int_val = m_settings->value("input/sample_rate", 0).toInt(&conv_ok);
     if (conv_ok && (int_val > 0))

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -73,61 +73,7 @@ CIoConfig::CIoConfig(QSettings * settings,
     ui->loSpinBox->setValue(1.0e-6 * settings->value("input/lnb_lo", 0.0).toDouble());
 
     // Output device
-    QString outdev = settings->value("output/device", "").toString();
-
-     // get list of audio output devices
-#ifdef WITH_PULSEAUDIO
-    pa_device_list devices;
-    outDevList = devices.get_output_devices();
-
-    qDebug() << __FUNCTION__ << ": Available output devices:";
-    for (size_t i = 0; i < outDevList.size(); i++)
-    {
-        qDebug() << "   " << i << ":" << QString(outDevList[i].get_description().c_str());
-        //qDebug() << "     " << QString(outDevList[i].get_name().c_str());
-        ui->outDevCombo->addItem(QString(outDevList[i].get_description().c_str()));
-
-        // note that item #i in devlist will be item #(i+1)
-        // in combo box due to "default"
-        if (outdev == QString(outDevList[i].get_name().c_str()))
-            ui->outDevCombo->setCurrentIndex(i+1);
-    }
-#elif WITH_PORTAUDIO
-    portaudio_device_list   devices;
-
-    outDevList = devices.get_output_devices();
-    for (size_t i = 0; i < outDevList.size(); i++)
-    {
-        ui->outDevCombo->addItem(QString(outDevList[i].get_description().c_str()));
-
-        // note that item #i in devlist will be item #(i+1)
-        // in combo box due to "default"
-        if (outdev == QString(outDevList[i].get_name().c_str()))
-            ui->outDevCombo->setCurrentIndex(i+1);
-    }
-    //ui->outDevCombo->setEditable(true);
-
-#elif defined(GQRX_OS_MACX)
-    osxaudio_device_list devices;
-    outDevList = devices.get_output_devices();
-
-    qDebug() << __FUNCTION__ << ": Available output devices:";
-    for (size_t i = 0; i < outDevList.size(); i++)
-    {
-        qDebug() << "   " << i << ":" << QString(outDevList[i].get_name().c_str());
-        ui->outDevCombo->addItem(QString(outDevList[i].get_name().c_str()));
-
-        // note that item #i in devlist will be item #(i+1)
-        // in combo box due to "default"
-        if (outdev == QString(outDevList[i].get_name().c_str()))
-            ui->outDevCombo->setCurrentIndex(i+1);
-    }
-
-#else
-    ui->outDevCombo->addItem(settings->value("output/device", "Default").toString(),
-                             settings->value("output/device", "Default").toString());
-    ui->outDevCombo->setEditable(true);
-#endif // WITH_PULSEAUDIO
+    updateOutDev();
 
     m_scanButton = new QPushButton("&Device scan", ui->buttonBox);
     ui->buttonBox->addButton(m_scanButton, QDialogButtonBox::ButtonRole::ActionRole);
@@ -142,6 +88,7 @@ CIoConfig::CIoConfig(QSettings * settings,
         m_devList->clear();
         CIoConfig::getDeviceList(*m_devList);
         updateInDev(m_settings, *m_devList);
+        updateOutDev();
     });
 }
 
@@ -681,6 +628,67 @@ void CIoConfig::updateInDev(const QSettings *settings, const std::map<QString, Q
             ui->inDevEdit->setText(indev);
         }
     }
+}
+
+void CIoConfig::updateOutDev()
+{
+    QString outdev = m_settings->value("output/device", "").toString();
+
+    ui->outDevCombo->clear();
+
+    // get list of audio output devices
+#ifdef WITH_PULSEAUDIO
+   pa_device_list devices;
+   outDevList = devices.get_output_devices();
+
+   qDebug() << __FUNCTION__ << ": Available output devices:";
+   for (size_t i = 0; i < outDevList.size(); i++)
+   {
+       qDebug() << "   " << i << ":" << QString(outDevList[i].get_description().c_str());
+       //qDebug() << "     " << QString(outDevList[i].get_name().c_str());
+       ui->outDevCombo->addItem(QString(outDevList[i].get_description().c_str()));
+
+       // note that item #i in devlist will be item #(i+1)
+       // in combo box due to "default"
+       if (outdev == QString(outDevList[i].get_name().c_str()))
+           ui->outDevCombo->setCurrentIndex(i+1);
+   }
+#elif WITH_PORTAUDIO
+   portaudio_device_list   devices;
+
+   outDevList = devices.get_output_devices();
+   for (size_t i = 0; i < outDevList.size(); i++)
+   {
+       ui->outDevCombo->addItem(QString(outDevList[i].get_description().c_str()));
+
+       // note that item #i in devlist will be item #(i+1)
+       // in combo box due to "default"
+       if (outdev == QString(outDevList[i].get_name().c_str()))
+           ui->outDevCombo->setCurrentIndex(i+1);
+   }
+   //ui->outDevCombo->setEditable(true);
+
+#elif defined(GQRX_OS_MACX)
+   osxaudio_device_list devices;
+   outDevList = devices.get_output_devices();
+
+   qDebug() << __FUNCTION__ << ": Available output devices:";
+   for (size_t i = 0; i < outDevList.size(); i++)
+   {
+       qDebug() << "   " << i << ":" << QString(outDevList[i].get_name().c_str());
+       ui->outDevCombo->addItem(QString(outDevList[i].get_name().c_str()));
+
+       // note that item #i in devlist will be item #(i+1)
+       // in combo box due to "default"
+       if (outdev == QString(outDevList[i].get_name().c_str()))
+           ui->outDevCombo->setCurrentIndex(i+1);
+   }
+
+#else
+   ui->outDevCombo->addItem(m_settings->value("output/device", "Default").toString(),
+                            m_settings->value("output/device", "Default").toString());
+   ui->outDevCombo->setEditable(true);
+#endif // WITH_PULSEAUDIO
 }
 
 /**

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -84,12 +84,7 @@ CIoConfig::CIoConfig(QSettings * settings,
     connect(ui->inDevEdit, SIGNAL(textChanged(QString)), this, SLOT(inputDevstrChanged(QString)));
     connect(ui->inSrCombo, SIGNAL(editTextChanged(QString)), this, SLOT(inputRateChanged(QString)));
     connect(ui->decimCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(decimationChanged(int)));
-    connect(m_scanButton, &QPushButton::clicked, this, [=](bool) {
-        m_devList->clear();
-        CIoConfig::getDeviceList(*m_devList);
-        updateInDev(m_settings, *m_devList);
-        updateOutDev();
-    });
+    connect(m_scanButton, SIGNAL(clicked(bool)), this, SLOT(onScanButtonClicked()));
 }
 
 CIoConfig::~CIoConfig()
@@ -758,6 +753,17 @@ void CIoConfig::decimationChanged(int index)
     else
         ui->sampRateLabel->setText(QString(" %1 ksps").
                                    arg(quad_rate * 1.e-3, 0, 'f', 3));
+}
+
+/**
+ * @brief Slot to handle device list updates on m_scanButton clicks
+ */
+void CIoConfig::onScanButtonClicked()
+{
+    m_devList->clear();
+    CIoConfig::getDeviceList(*m_devList);
+    updateInDev(m_settings, *m_devList);
+    updateOutDev();
 }
 
 /** Convert a combo box index to decimation. */

--- a/src/qtgui/ioconfig.h
+++ b/src/qtgui/ioconfig.h
@@ -56,6 +56,7 @@ private slots:
     void inputDevstrChanged(const QString &text);
     void inputRateChanged(const QString &text);
     void decimationChanged(int index);
+    void onScanButtonClicked();
 
 private:
     void updateInputSampleRates(int rate);

--- a/src/qtgui/ioconfig.h
+++ b/src/qtgui/ioconfig.h
@@ -61,6 +61,7 @@ private:
     void updateInputSampleRates(int rate);
     void updateDecimations(void);
     void updateInDev(const QSettings *settings, const std::map<QString, QVariant> &devList);
+    void updateOutDev();
     int  idx2decim(int idx) const;
     int  decim2idx(int decim) const;
 

--- a/src/qtgui/ioconfig.h
+++ b/src/qtgui/ioconfig.h
@@ -60,12 +60,15 @@ private slots:
 private:
     void updateInputSampleRates(int rate);
     void updateDecimations(void);
+    void updateInDev(const QSettings *settings, const std::map<QString, QVariant> &devList);
     int  idx2decim(int idx) const;
     int  decim2idx(int decim) const;
 
 private:
     Ui::CIoConfig  *ui;
     QSettings      *m_settings;
+    QPushButton    *m_scanButton;
+    std::map<QString, QVariant> *m_devList; // will point to devList from constructor
 
 #ifdef WITH_PULSEAUDIO
     vector<pa_device>           outDevList;

--- a/src/qtgui/ioconfig.ui
+++ b/src/qtgui/ioconfig.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>303</width>
-    <height>413</height>
+    <width>322</width>
+    <height>438</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
This adds a new button **Device scan** to IOConfig.
Updates input and output device list.

No need to restart on (un)plugin different devices. Just reconfigure and click OK.

![gqrx-update-devlist](https://user-images.githubusercontent.com/5228369/76020539-e2b18400-5f23-11ea-84ad-e54be259eed2.png)

