### PR TITLE
Tweaks to RDS demodulation for a more stable decoding

### DIFF
--- a/src/dsp/rx_rds.cpp
+++ b/src/dsp/rx_rds.cpp
@@ -4,7 +4,7 @@
  *           http://gqrx.dk/
  *
  * Copyright 2011 Alexandru Csete OZ9AEC.
- *
+ * 
  * Gqrx is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3, or (at your option)
@@ -56,14 +56,16 @@ rx_rds::rx_rds(double sample_rate)
                       gr::io_signature::make (MIN_OUT, MAX_OUT, sizeof (char))),
       d_sample_rate(sample_rate)
 {
-    const int decimation = d_sample_rate / 2375;
-
     d_taps2 = gr::filter::firdes::low_pass(2500.0, d_sample_rate, 2400, 2000);
 
-    f_fxff = gr::filter::freq_xlating_fir_filter_fcf::make(decimation, d_taps2, 57000, d_sample_rate);
+    f_fxff = gr::filter::freq_xlating_fir_filter_fcf::make(1, d_taps2, 57000, d_sample_rate);
 
-    f_rrcf = gr::filter::firdes::root_raised_cosine(1, sample_rate/decimation, 2375, 1, 100);
+    d_rsmp_tap = gr::filter::firdes::low_pass(10, d_sample_rate, 2375, 2000);
+    d_rsmp = gr::filter::pfb_arb_resampler_ccf::make(2375/d_sample_rate,d_rsmp_tap,32);
+
+    f_rrcf = gr::filter::firdes::root_raised_cosine(1, 2375, 2375, 1, 100);
     d_bpf2 = gr::filter::fir_filter_ccf::make(1, f_rrcf);
+
 
     gr::digital::constellation_sptr p_c = gr::digital::constellation_bpsk::make()->base();
     d_mpsk = gr::digital::constellation_receiver_cb::make(p_c, 1*M_PI/100.0, -0.06, 0.06);
@@ -76,8 +78,9 @@ rx_rds::rx_rds(double sample_rate)
     rds_parser = gr::rds::parser::make(1, 0, 0);
 
     /* connect filter */
-    connect(self(), 0, f_fxff, 0);
-    connect(f_fxff, 0, d_bpf2, 0);
+    connect(self(), 0, f_fxff, 0); 
+    connect(f_fxff, 0, d_rsmp, 0); 
+    connect(d_rsmp, 0, d_bpf2, 0);
     connect(d_bpf2, 0, d_mpsk, 0);
     connect(d_mpsk, 0, b_koin, 0);
     connect(b_koin, 0, d_ddbb, 0);

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -35,6 +35,7 @@
 #include <gnuradio/filter/fir_filter_blk.h>
 #include <gnuradio/filter/freq_xlating_fir_filter.h>
 #endif
+#include <gnuradio/filter/pfb_arb_resampler_ccf.h>
 
 #include <gnuradio/digital/constellation_receiver_cb.h>
 #include <gnuradio/blocks/keep_one_in_n.h>
@@ -85,10 +86,10 @@ public:
 private:
     std::vector<gr_complex> d_taps;
     std::vector<float> d_taps2;
-    gr::filter::fir_filter_ccc::sptr  d_bpf;
+    std::vector<float> d_rsmp_tap;
     gr::filter::fir_filter_ccf::sptr  d_bpf2;
     gr::filter::freq_xlating_fir_filter_fcf::sptr f_fxff;
-    gr::filter::freq_xlating_fir_filter_ccf::sptr f_fxff_ccf;
+    gr::filter::pfb_arb_resampler_ccf::sptr d_rsmp;
     std::vector<float> f_rrcf;
     gr::digital::constellation_receiver_cb::sptr d_mpsk;
     gr::blocks::keep_one_in_n::sptr b_koin;


### PR DESCRIPTION
This patch is to mitigate against a situation where even the big local blowtorch FM stations were decoding RDS only intermittently - one could notice how periodically(once in a couple of seconds if not more frequently) the decoding just cut out as if something was multiplying the downconverted RDS symbols with a sine wave. 

The new setup still isn't perfect but is a noticeable improvement over the current situation. It also appears that a number of stations here in Estonia do not have their RDS signal apparently exactly at 57 kHz, but a few hertz off. Some stations are more off than others. If you are interested, I can provide I/Q recordings of the bigger trouble-makers. I sure wonder if it could be more optimal to derive the exact RDS frequency from the stereo pilot tone.