### PR TITLE
Print Configuration For UDP Streaming

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.13.2: In progress...
 
        NEW: Preliminary support for GNU Radio 3.9.
+       NEW: Print UDP configuration.
      FIXED: Loss of precision in the plotter's frequency axis.
 
 

--- a/src/interfaces/udp_sink_f.cpp
+++ b/src/interfaces/udp_sink_f.cpp
@@ -25,6 +25,8 @@
 #include <gnuradio/blocks/udp_sink.h>
 #include <gnuradio/io_signature.h>
 
+#include <iostream>
+
 #include "udp_sink_f.h"
 
 
@@ -81,6 +83,10 @@ void udp_sink_f::start_streaming(const std::string host, int port, bool stereo)
     lock();
     disconnect_all();
 
+    std::cout << "Starting UDP streaming, Host:" << host;
+    std::cout << ", Port:" << std::to_string(port) << ", ";
+    std::cout <<  (stereo? "Stereo" : "Mono") << std::endl;
+
     if (stereo)
     {
         connect(self(), 0, d_inter, 0);
@@ -107,6 +113,8 @@ void udp_sink_f::stop_streaming(void)
     connect(self(), 0, d_null0, 0);
     connect(self(), 1, d_null1, 0);
     unlock();
+
+    std::cout << "Disconnected UDP streaming" << std::endl;
 
     d_sink->disconnect();
 }

--- a/src/interfaces/udp_sink_f.cpp
+++ b/src/interfaces/udp_sink_f.cpp
@@ -83,9 +83,9 @@ void udp_sink_f::start_streaming(const std::string host, int port, bool stereo)
     lock();
     disconnect_all();
 
-    std::cout << "Starting UDP streaming, Host:" << host;
-    std::cout << ", Port:" << std::to_string(port) << ", ";
-    std::cout <<  (stereo? "Stereo" : "Mono") << std::endl;
+    std::cout << "Starting UDP streaming, Host: " << host;
+    std::cout << ", Port: " << std::to_string(port) << ", ";
+    std::cout << (stereo ? "Stereo" : "Mono") << std::endl;
 
     if (stereo)
     {


### PR DESCRIPTION
Added some cout statements to print the network configuration when
connecting/disconnecting UDP streaming. I found this very helpful when
debugging why it seemed to be intermittently not working on my system.
(Turned out I was switching between IPv4 and IPv6 stacks inadvertently)

Signed-off-by: Ben Reese <5884008+benreese0@users.noreply.github.com>