### PR TITLE
Add libvolk as an exilicit dependency

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(${PROJECT_NAME}
     ${PULSEAUDIO_LIBRARY}
     ${PULSE-SIMPLE}
     ${PORTAUDIO_LIBRARIES}
+    volk
 )
 
 if(NOT Gnuradio_VERSION VERSION_LESS "3.8")
@@ -80,6 +81,7 @@ if(NOT Gnuradio_VERSION VERSION_LESS "3.8")
         gnuradio::gnuradio-digital
         gnuradio::gnuradio-filter
         gnuradio::gnuradio-audio
+        volk
     )
 endif()
 


### PR DESCRIPTION
Fixes #795.

Gqrx started using libvolk directly in #770, so I'm adding it to `target_link_libraries` to ensure that it's linked. I've verified Gqrx builds successfully against GNU Radio 3.8 (installed with PyBOMBS on Ubuntu 20.04), and GNU Radio 3.7 (installed with Homebrew on macOS 10.15).