### PR TITLE
Use std::shared_ptr with GNU Radio 3.9

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,6 +1,7 @@
 
     2.13.2: In progress...
 
+       NEW: Preliminary support for GNU Radio 3.9.
      FIXED: Loss of precision in the plotter's frequency axis.
 
 

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -1002,9 +1002,15 @@ receiver::status receiver::start_audio_recording(const std::string filename)
 
     // if this fails, we don't want to go and crash now, do we
     try {
+#if GNURADIO_VERSION < 0x030900
         wav_sink = gr::blocks::wavfile_sink::make(filename.c_str(), 2,
                                                   (unsigned int) d_audio_rate,
                                                   16);
+#else
+        wav_sink = gr::blocks::wavfile_sink::make(filename.c_str(), 2,
+                                                  (unsigned int) d_audio_rate,
+                                                  gr::blocks::FORMAT_WAV, gr::blocks::FORMAT_PCM_16);
+#endif
     }
     catch (std::runtime_error &e) {
         std::cout << "Error opening " << filename << ": " << e.what() << std::endl;

--- a/src/dsp/correct_iq_cc.h
+++ b/src/dsp/correct_iq_cc.h
@@ -38,8 +38,13 @@
 class dc_corr_cc;
 class iq_swap_cc;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<dc_corr_cc> dc_corr_cc_sptr;
 typedef boost::shared_ptr<iq_swap_cc> iq_swap_cc_sptr;
+#else
+typedef std::shared_ptr<dc_corr_cc> dc_corr_cc_sptr;
+typedef std::shared_ptr<iq_swap_cc> iq_swap_cc_sptr;
+#endif
 
 /*! \brief Return a shared_ptr to a new instance of dc_corr_cc.
  *  \param sample_rate The sample rate

--- a/src/dsp/downconverter.h
+++ b/src/dsp/downconverter.h
@@ -33,7 +33,11 @@
 
 class downconverter_cc;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<downconverter_cc> downconverter_cc_sptr;
+#else
+typedef std::shared_ptr<downconverter_cc> downconverter_cc_sptr;
+#endif
 downconverter_cc_sptr make_downconverter_cc(unsigned int decim, double center_freq, double samp_rate);
 
 class downconverter_cc : public gr::hier_block2

--- a/src/dsp/filter/fir_decim.h
+++ b/src/dsp/filter/fir_decim.h
@@ -32,7 +32,11 @@
 
 class fir_decim_cc;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<fir_decim_cc> fir_decim_cc_sptr;
+#else
+typedef std::shared_ptr<fir_decim_cc> fir_decim_cc_sptr;
+#endif
 fir_decim_cc_sptr make_fir_decim_cc(unsigned int decim);
 
 class fir_decim_cc : public gr::hier_block2

--- a/src/dsp/fm_deemph.h
+++ b/src/dsp/fm_deemph.h
@@ -27,7 +27,11 @@
 #include <vector>
 
 class fm_deemph;
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<fm_deemph> fm_deemph_sptr;
+#else
+typedef std::shared_ptr<fm_deemph> fm_deemph_sptr;
+#endif
 
 /*! \brief Return a shared_ptr to a new instance of fm_deemph.
  *  \param quad_rate The input sample rate.

--- a/src/dsp/hbf_decim.h
+++ b/src/dsp/hbf_decim.h
@@ -25,7 +25,11 @@
 #include "filter/decimator.h"
 
 class hbf_decim;
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<hbf_decim> hbf_decim_sptr;
+#else
+typedef std::shared_ptr<hbf_decim> hbf_decim_sptr;
+#endif
 hbf_decim_sptr make_hbf_decim(unsigned int decim);
 
 /**

--- a/src/dsp/lpf.h
+++ b/src/dsp/lpf.h
@@ -35,7 +35,11 @@
 
 class lpf_ff;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<lpf_ff> lpf_ff_sptr;
+#else
+typedef std::shared_ptr<lpf_ff> lpf_ff_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of lpf.

--- a/src/dsp/rds/decoder.h
+++ b/src/dsp/rds/decoder.h
@@ -26,7 +26,11 @@ namespace rds {
 class RDS_API decoder : virtual public gr::sync_block
 {
 public:
+#if GNURADIO_VERSION < 0x030900
 	typedef boost::shared_ptr<decoder> sptr;
+#else
+	typedef std::shared_ptr<decoder> sptr;
+#endif
 	static sptr make(bool log, bool debug);
 };
 

--- a/src/dsp/rds/parser.h
+++ b/src/dsp/rds/parser.h
@@ -26,7 +26,11 @@ namespace rds {
 class RDS_API parser : virtual public gr::block
 {
 public:
+#if GNURADIO_VERSION < 0x030900
 	typedef boost::shared_ptr<parser> sptr;
+#else
+	typedef std::shared_ptr<parser> sptr;
+#endif
 	static sptr make(bool log, bool debug, unsigned char pty_locale);
 
 	virtual void reset() = 0;

--- a/src/dsp/resampler_ff_old.h
+++ b/src/dsp/resampler_ff_old.h
@@ -27,7 +27,11 @@
 class resampler_ffo;
 
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<resampler_ffo> resampler_ffo_sptr;
+#else
+typedef std::shared_ptr<resampler_ffo> resampler_ffo_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of resampler_ff.

--- a/src/dsp/resampler_xx.h
+++ b/src/dsp/resampler_xx.h
@@ -31,8 +31,13 @@
 class resampler_cc;
 class resampler_ff;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<resampler_cc> resampler_cc_sptr;
 typedef boost::shared_ptr<resampler_ff> resampler_ff_sptr;
+#else
+typedef std::shared_ptr<resampler_cc> resampler_cc_sptr;
+typedef std::shared_ptr<resampler_ff> resampler_ff_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of resampler_cc.

--- a/src/dsp/rx_agc_xx.h
+++ b/src/dsp/rx_agc_xx.h
@@ -30,7 +30,11 @@
 
 class rx_agc_cc;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_agc_cc> rx_agc_cc_sptr;
+#else
+typedef std::shared_ptr<rx_agc_cc> rx_agc_cc_sptr;
+#endif
 
 
 /**

--- a/src/dsp/rx_demod_am.h
+++ b/src/dsp/rx_demod_am.h
@@ -32,7 +32,11 @@
 
 class rx_demod_am;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_demod_am> rx_demod_am_sptr;
+#else
+typedef std::shared_ptr<rx_demod_am> rx_demod_am_sptr;
+#endif
 
 /*! \brief Return a shared_ptr to a new instance of rx_demod_am.
  *  \param quad_rate The input sample rate.

--- a/src/dsp/rx_demod_fm.h
+++ b/src/dsp/rx_demod_fm.h
@@ -28,7 +28,11 @@
 #include "dsp/fm_deemph.h"
 
 class rx_demod_fm;
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_demod_fm> rx_demod_fm_sptr;
+#else
+typedef std::shared_ptr<rx_demod_fm> rx_demod_fm_sptr;
+#endif
 
 /*! \brief Return a shared_ptr to a new instance of rx_demod_fm.
  *  \param quad_rate The input sample rate.

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -37,8 +37,13 @@
 class rx_fft_c;
 class rx_fft_f;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_fft_c> rx_fft_c_sptr;
 typedef boost::shared_ptr<rx_fft_f> rx_fft_f_sptr;
+#else
+typedef std::shared_ptr<rx_fft_c> rx_fft_c_sptr;
+typedef std::shared_ptr<rx_fft_f> rx_fft_f_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of rx_fft_c.

--- a/src/dsp/rx_filter.h
+++ b/src/dsp/rx_filter.h
@@ -39,8 +39,13 @@
 class rx_filter;
 class rx_xlating_filter;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_filter> rx_filter_sptr;
 typedef boost::shared_ptr<rx_xlating_filter> rx_xlating_filter_sptr;
+#else
+typedef std::shared_ptr<rx_filter> rx_filter_sptr;
+typedef std::shared_ptr<rx_xlating_filter> rx_xlating_filter_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of rx_filter.

--- a/src/dsp/rx_meter.h
+++ b/src/dsp/rx_meter.h
@@ -37,7 +37,11 @@ enum detector_type_e {
 
 class rx_meter_c;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_meter_c> rx_meter_c_sptr;
+#else
+typedef std::shared_ptr<rx_meter_c> rx_meter_c_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of rx_meter_c.

--- a/src/dsp/rx_noise_blanker_cc.h
+++ b/src/dsp/rx_noise_blanker_cc.h
@@ -29,7 +29,11 @@
 
 class rx_nb_cc;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_nb_cc> rx_nb_cc_sptr;
+#else
+typedef std::shared_ptr<rx_nb_cc> rx_nb_cc_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of rx_nb_cc.

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -51,8 +51,13 @@
 class rx_rds;
 class rx_rds_store;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<rx_rds> rx_rds_sptr;
 typedef boost::shared_ptr<rx_rds_store> rx_rds_store_sptr;
+#else
+typedef std::shared_ptr<rx_rds> rx_rds_sptr;
+typedef std::shared_ptr<rx_rds_store> rx_rds_store_sptr;
+#endif
 
 
 rx_rds_sptr make_rx_rds(double sample_rate);

--- a/src/dsp/sniffer_f.h
+++ b/src/dsp/sniffer_f.h
@@ -30,7 +30,11 @@
 
 class sniffer_f;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<sniffer_f> sniffer_f_sptr;
+#else
+typedef std::shared_ptr<sniffer_f> sniffer_f_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of sniffer_f.

--- a/src/dsp/stereo_demod.h
+++ b/src/dsp/stereo_demod.h
@@ -51,7 +51,11 @@
 
 class stereo_demod;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<stereo_demod> stereo_demod_sptr;
+#else
+typedef std::shared_ptr<stereo_demod> stereo_demod_sptr;
+#endif
 
 
 /*! \brief Return a shared_ptr to a new instance of stere_demod.

--- a/src/interfaces/udp_sink_f.h
+++ b/src/interfaces/udp_sink_f.h
@@ -32,7 +32,11 @@
 
 class udp_sink_f;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<udp_sink_f> udp_sink_f_sptr;
+#else
+typedef std::shared_ptr<udp_sink_f> udp_sink_f_sptr;
+#endif
 
 udp_sink_f_sptr make_udp_sink_f(void);
 

--- a/src/portaudio/portaudio_sink.h
+++ b/src/portaudio/portaudio_sink.h
@@ -30,7 +30,11 @@ using namespace std;
 
 class portaudio_sink;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<portaudio_sink> portaudio_sink_sptr;
+#else
+typedef std::shared_ptr<portaudio_sink> portaudio_sink_sptr;
+#endif
 
 portaudio_sink_sptr make_portaudio_sink(const string device_name, int audio_rate,
                                         const string app_name,

--- a/src/pulseaudio/pa_sink.h
+++ b/src/pulseaudio/pa_sink.h
@@ -31,7 +31,11 @@ using namespace std;
 
 class pa_sink;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<pa_sink> pa_sink_sptr;
+#else
+typedef std::shared_ptr<pa_sink> pa_sink_sptr;
+#endif
 
 pa_sink_sptr make_pa_sink(const string device_name, int audio_rate,
                           const string app_name,

--- a/src/pulseaudio/pa_source.h
+++ b/src/pulseaudio/pa_source.h
@@ -31,7 +31,11 @@ using namespace std;
 
 class pa_source;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<pa_source> pa_source_sptr;
+#else
+typedef std::shared_ptr<pa_source> pa_source_sptr;
+#endif
 
 pa_source_sptr make_pa_source(const string device_name,
                               int sample_rate,

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -39,7 +39,11 @@
 
 class nbrx;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<nbrx> nbrx_sptr;
+#else
+typedef std::shared_ptr<nbrx> nbrx_sptr;
+#endif
 
 /*! \brief Public constructor of nbrx_sptr. */
 nbrx_sptr make_nbrx(float quad_rate, float audio_rate);

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -28,7 +28,11 @@
 
 class receiver_base_cf;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<receiver_base_cf> receiver_base_cf_sptr;
+#else
+typedef std::shared_ptr<receiver_base_cf> receiver_base_cf_sptr;
+#endif
 
 
 /*! \brief Base class for receivers that output audio.

--- a/src/receivers/wfmrx.h
+++ b/src/receivers/wfmrx.h
@@ -38,7 +38,11 @@
 
 class wfmrx;
 
+#if GNURADIO_VERSION < 0x030900
 typedef boost::shared_ptr<wfmrx> wfmrx_sptr;
+#else
+typedef std::shared_ptr<wfmrx> wfmrx_sptr;
+#endif
 
 /*! \brief Public constructor of wfm_rx. */
 wfmrx_sptr make_wfmrx(float quad_rate, float audio_rate);


### PR DESCRIPTION
In the upcoming version 3.9, GNU Radio is switching from `boost::shared_ptr` to `std::shared_ptr`:

https://wiki.gnuradio.org/index.php/GNU_Radio_3.9_OOT_Module_Porting_Guide#C.2B.2B_Modernization

As a result, Gqrx will need to do the same for its blocks. I've added preprocessor conditionals to check the GNU Radio version and use the appropriate shared pointer type. I've tested this change on GNU Radio's `maint-3.8` branch as well as `master`.

Note: Similar changes are also needed for the gr-iqbal and gr-osmosdr dependencies. I used these branches when testing Gqrx against GNU Radio's master branch:

https://github.com/argilo/gr-iqbal/tree/gr3.9
https://github.com/argilo/gr-osmosdr/tree/gr3.9
