### PR TITLE
Synchronous AM demodulation

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -4,6 +4,7 @@
        NEW: Start/stop DSP via remote control.
        NEW: Device scan button in Configure I/O devices dialog.
        NEW: Added "Recent settings" menu.
+       NEW: Added synchronous AM demodulator.
 
 
     2.13.5: Released November 7, 2020

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -208,6 +208,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(uiDockRxOpt, SIGNAL(fmEmphSelected(double)), this, SLOT(setFmEmph(double)));
     connect(uiDockRxOpt, SIGNAL(amDcrToggled(bool)), this, SLOT(setAmDcr(bool)));
     connect(uiDockRxOpt, SIGNAL(cwOffsetChanged(int)), this, SLOT(setCwOffset(int)));
+    connect(uiDockRxOpt, SIGNAL(amSyncDcrToggled(bool)), this, SLOT(setAmSyncDcr(bool)));
     connect(uiDockRxOpt, SIGNAL(agcToggled(bool)), this, SLOT(setAgcOn(bool)));
     connect(uiDockRxOpt, SIGNAL(agcHangToggled(bool)), this, SLOT(setAgcHang(bool)));
     connect(uiDockRxOpt, SIGNAL(agcThresholdChanged(int)), this, SLOT(setAgcThreshold(int)));
@@ -1086,6 +1087,13 @@ void MainWindow::selectDemod(int mode_idx)
         click_res = 100;
         break;
 
+    case DockRxOpt::MODE_AM_SYNC:
+        rx->set_demod(receiver::RX_DEMOD_AMSYNC);
+        ui->plotter->setDemodRanges(-40000, -200, 200, 40000, true);
+        uiDockAudio->setFftRange(0,6000);
+        click_res = 100;
+        break;
+
     case DockRxOpt::MODE_NFM:
         ui->plotter->setDemodRanges(-40000, -1000, 1000, 40000, true);
         uiDockAudio->setFftRange(0, 5000);
@@ -1211,6 +1219,15 @@ void MainWindow::setAmDcr(bool enabled)
 void MainWindow::setCwOffset(int offset)
 {
     rx->set_cw_offset(offset);
+}
+
+/**
+ * @brief AM-Sync DCR status changed (slot).
+ * @param enabled Whether DCR is enabled or not.
+ */
+void MainWindow::setAmSyncDcr(bool enabled)
+{
+    rx->set_amsync_dcr(enabled);
 }
 
 /**

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -209,6 +209,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(uiDockRxOpt, SIGNAL(amDcrToggled(bool)), this, SLOT(setAmDcr(bool)));
     connect(uiDockRxOpt, SIGNAL(cwOffsetChanged(int)), this, SLOT(setCwOffset(int)));
     connect(uiDockRxOpt, SIGNAL(amSyncDcrToggled(bool)), this, SLOT(setAmSyncDcr(bool)));
+    connect(uiDockRxOpt, SIGNAL(amSyncPllBwSelected(float)), this, SLOT(setAmSyncPllBw(float)));
     connect(uiDockRxOpt, SIGNAL(agcToggled(bool)), this, SLOT(setAgcOn(bool)));
     connect(uiDockRxOpt, SIGNAL(agcHangToggled(bool)), this, SLOT(setAgcHang(bool)));
     connect(uiDockRxOpt, SIGNAL(agcThresholdChanged(int)), this, SLOT(setAgcThreshold(int)));
@@ -1228,6 +1229,18 @@ void MainWindow::setCwOffset(int offset)
 void MainWindow::setAmSyncDcr(bool enabled)
 {
     rx->set_amsync_dcr(enabled);
+}
+
+/**
+ * @brief New AM-Sync PLL BW selected.
+ * @param pll_bw The new PLL BW.
+ */
+void MainWindow::setAmSyncPllBw(float pll_bw)
+{
+    qDebug() << "AM-Sync PLL BW: " << pll_bw;
+
+    /* receiver will check range */
+    rx->set_amsync_pll_bw(pll_bw);
 }
 
 /**

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -155,6 +155,7 @@ private slots:
     void setAmDcr(bool enabled);
     void setCwOffset(int offset);
     void setAmSyncDcr(bool enabled);
+    void setAmSyncPllBw(float pll_bw);
     void setAgcOn(bool agc_on);
     void setAgcHang(bool use_hang);
     void setAgcThreshold(int threshold);

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -154,6 +154,7 @@ private slots:
     void setFmEmph(double tau);
     void setAmDcr(bool enabled);
     void setCwOffset(int offset);
+    void setAmSyncDcr(bool enabled);
     void setAgcOn(bool agc_on);
     void setAgcHang(bool use_hang);
     void setAgcThreshold(int threshold);

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -887,6 +887,11 @@ receiver::status receiver::set_demod(rx_demod demod)
         rx->set_demod(nbrx::NBRX_DEMOD_AM);
         break;
 
+    case RX_DEMOD_AMSYNC:
+        connect_all(RX_CHAIN_NBRX);
+        rx->set_demod(nbrx::NBRX_DEMOD_AMSYNC);
+        break;
+
     case RX_DEMOD_NFM:
         connect_all(RX_CHAIN_NBRX);
         rx->set_demod(nbrx::NBRX_DEMOD_FM);
@@ -949,6 +954,14 @@ receiver::status receiver::set_am_dcr(bool enabled)
 {
     if (rx->has_am())
         rx->set_am_dcr(enabled);
+
+    return STATUS_OK;
+}
+
+receiver::status receiver::set_amsync_dcr(bool enabled)
+{
+    if (rx->has_amsync())
+        rx->set_amsync_dcr(enabled);
 
     return STATUS_OK;
 }

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -966,6 +966,14 @@ receiver::status receiver::set_amsync_dcr(bool enabled)
     return STATUS_OK;
 }
 
+receiver::status receiver::set_amsync_pll_bw(float pll_bw)
+{
+    if (rx->has_amsync())
+        rx->set_amsync_pll_bw(pll_bw);
+
+    return STATUS_OK;
+}
+
 receiver::status receiver::set_af_gain(float gain_db)
 {
     float k;

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -92,7 +92,8 @@ public:
         RX_DEMOD_WFM_M = 4,  /*!< Frequency modulation (wide, mono). */
         RX_DEMOD_WFM_S = 5,  /*!< Frequency modulation (wide, stereo). */
         RX_DEMOD_WFM_S_OIRT = 6,  /*!< Frequency modulation (wide, stereo oirt). */
-        RX_DEMOD_SSB   = 7   /*!< Single Side Band. */
+        RX_DEMOD_SSB   = 7,  /*!< Single Side Band. */
+        RX_DEMOD_AMSYNC = 8  /*!< Amplitude modulation. */
     };
 
     /** Supported receiver types. */
@@ -193,6 +194,9 @@ public:
 
     /* AM parameters */
     status      set_am_dcr(bool enabled);
+
+    /* AM-Sync parameters */
+    status      set_amsync_dcr(bool enabled);
 
     /* Audio parameters */
     status      set_af_gain(float gain_db);

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -93,7 +93,7 @@ public:
         RX_DEMOD_WFM_S = 5,  /*!< Frequency modulation (wide, stereo). */
         RX_DEMOD_WFM_S_OIRT = 6,  /*!< Frequency modulation (wide, stereo oirt). */
         RX_DEMOD_SSB   = 7,  /*!< Single Side Band. */
-        RX_DEMOD_AMSYNC = 8  /*!< Amplitude modulation. */
+        RX_DEMOD_AMSYNC = 8  /*!< Amplitude modulation (synchronous demod). */
     };
 
     /** Supported receiver types. */

--- a/src/applications/gqrx/receiver.h
+++ b/src/applications/gqrx/receiver.h
@@ -197,6 +197,7 @@ public:
 
     /* AM-Sync parameters */
     status      set_amsync_dcr(bool enabled);
+    status      set_amsync_pll_bw(float pll_bw);
 
     /* Audio parameters */
     status      set_af_gain(float gain_db);

--- a/src/dsp/rx_demod_am.cpp
+++ b/src/dsp/rx_demod_am.cpp
@@ -105,12 +105,6 @@ void rx_demod_am::set_dcr(bool dcr)
     d_dcr_enabled = dcr;
 }
 
-/*! \brief Get current DCR status. */
-bool rx_demod_am::dcr()
-{
-    return d_dcr_enabled;
-}
-
 /* Create a new instance of rx_demod_amsync and return a boost shared_ptr. */
 rx_demod_amsync_sptr make_rx_demod_amsync(float quad_rate, bool dcr, float pll_bw)
 {
@@ -187,12 +181,6 @@ void rx_demod_amsync::set_dcr(bool dcr)
     }
 
     d_dcr_enabled = dcr;
-}
-
-/*! \brief Get current DCR status. */
-bool rx_demod_amsync::dcr()
-{
-    return d_dcr_enabled;
 }
 
 /*! \brief Set PLL loop bandwidth.

--- a/src/dsp/rx_demod_am.h
+++ b/src/dsp/rx_demod_am.h
@@ -86,10 +86,11 @@ private:
 /*! \brief Return a shared_ptr to a new instance of rx_demod_amsync.
  *  \param quad_rate The input sample rate.
  *  \param dcr Enable DCR
+ *  \param pll_bw The new PLL BW.
  *
  * This is effectively the public constructor.
  */
-rx_demod_amsync_sptr make_rx_demod_amsync(float quad_rate, bool dcr=true);
+rx_demod_amsync_sptr make_rx_demod_amsync(float quad_rate, bool dcr=true, float pll_bw=0.001);
 
 
 /*! \brief Synchronous AM demodulator.
@@ -105,10 +106,11 @@ class rx_demod_amsync : public gr::hier_block2
 {
 
 public:
-    rx_demod_amsync(float quad_rate, bool dcr=true); // FIXME: could be private
+    rx_demod_amsync(float quad_rate, bool dcr=true, float pll_bw=0.001); // FIXME: could be private
     ~rx_demod_amsync();
 
     void set_dcr(bool dcr);
+    void set_pll_bw(float pll_bw);
     bool dcr();
 
 private:

--- a/src/dsp/rx_demod_am.h
+++ b/src/dsp/rx_demod_am.h
@@ -66,7 +66,6 @@ public:
     ~rx_demod_am();
 
     void set_dcr(bool dcr);
-    bool dcr();
 
 private:
     /* GR blocks */
@@ -111,7 +110,6 @@ public:
 
     void set_dcr(bool dcr);
     void set_pll_bw(float pll_bw);
-    bool dcr();
 
 private:
     /* GR blocks */

--- a/src/qtgui/demod_options.cpp
+++ b/src/qtgui/demod_options.cpp
@@ -90,6 +90,42 @@ int maxdev_to_index(float max_dev)
         return 3;
 }
 
+/* convert between synchronous AM PLL bandwidth and combo index */
+static float pll_bw_from_index(int index)
+{
+    switch(index)
+    {
+    case 0:
+        /* Fast */
+        return 0.01;
+    case 1:
+        /* Medium */
+        return 0.001;
+    case 2:
+        /* Slow */
+        return 0.0001;
+    default:
+        qDebug() << "Invalid AM-Sync PLL BW index: " << index;
+        return 0.001;
+    }
+}
+
+static int pll_bw_to_index(float pll_bw)
+{
+    if (pll_bw < 0.00015)
+        /* Slow */
+        return 2;
+    else if (pll_bw < 0.0015)
+        /* Medium */
+        return 1;
+    else if (pll_bw < 0.015)
+        /* Fast */
+        return 0;
+    else
+        /* Medium */
+        return 1;
+}
+
 CDemodOptions::CDemodOptions(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::CDemodOptions)
@@ -179,4 +215,19 @@ void CDemodOptions::on_cwOffsetSpin_valueChanged(int value)
 void CDemodOptions::on_syncdcrCheckBox_toggled(bool checked)
 {
     emit amSyncDcrToggled(checked);
+}
+
+void CDemodOptions::setPllBw(float pll_bw)
+{
+    ui->pllBwSelector->setCurrentIndex(pll_bw_to_index(pll_bw));
+}
+
+float CDemodOptions::getPllBw(void) const
+{
+    return pll_bw_from_index(ui->pllBwSelector->currentIndex());
+}
+
+void CDemodOptions::on_pllBwSelector_activated(int index)
+{
+    emit amSyncPllBwSelected(pll_bw_from_index(index));
 }

--- a/src/qtgui/demod_options.cpp
+++ b/src/qtgui/demod_options.cpp
@@ -175,3 +175,8 @@ void CDemodOptions::on_cwOffsetSpin_valueChanged(int value)
 {
     emit cwOffsetChanged(value);
 }
+
+void CDemodOptions::on_syncdcrCheckBox_toggled(bool checked)
+{
+    emit amSyncDcrToggled(checked);
+}

--- a/src/qtgui/demod_options.h
+++ b/src/qtgui/demod_options.h
@@ -67,6 +67,9 @@ public:
     void setEmph(double tau);
     double getEmph(void) const;
 
+    void setPllBw(float pll_bw);
+    float getPllBw(void) const;
+
 signals:
     /*! \brief Signal emitted when new FM deviation is selected. */
     void fmMaxdevSelected(float max_dev);
@@ -83,12 +86,16 @@ signals:
     /*! \brief Signal emitted when AM-Sync DCR is toggled. */
     void amSyncDcrToggled(bool enabled);
 
+    /*! \brief Signal emitted when new PLL BW is selected. */
+    void amSyncPllBwSelected(float pll_bw);
+
 private slots:
     void on_maxdevSelector_activated(int index);
     void on_emphSelector_activated(int index);
     void on_dcrCheckBox_toggled(bool checked);
     void on_cwOffsetSpin_valueChanged(int value);
     void on_syncdcrCheckBox_toggled(bool checked);
+    void on_pllBwSelector_activated(int index);
 
 private:
     Ui::CDemodOptions *ui;

--- a/src/qtgui/demod_options.h
+++ b/src/qtgui/demod_options.h
@@ -46,7 +46,8 @@ public:
         PAGE_FM_OPT = 1,
         PAGE_AM_OPT = 2,
         PAGE_CW_OPT = 3,
-        PAGE_NUM    = 4
+        PAGE_AMSYNC_OPT = 4,
+        PAGE_NUM    = 5
     };
 
     explicit CDemodOptions(QWidget *parent = 0);
@@ -79,11 +80,15 @@ signals:
     /*! \brief CW offset changed. */
     void cwOffsetChanged(int offset);
 
+    /*! \brief Signal emitted when AM-Sync DCR is toggled. */
+    void amSyncDcrToggled(bool enabled);
+
 private slots:
     void on_maxdevSelector_activated(int index);
     void on_emphSelector_activated(int index);
     void on_dcrCheckBox_toggled(bool checked);
     void on_cwOffsetSpin_valueChanged(int value);
+    void on_syncdcrCheckBox_toggled(bool checked);
 
 private:
     Ui::CDemodOptions *ui;

--- a/src/qtgui/demod_options.ui
+++ b/src/qtgui/demod_options.ui
@@ -263,17 +263,94 @@ For digital modes it is best to switch it off.</string>
      <widget class="QWidget" name="demodAmSyncOpt">
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QCheckBox" name="syncdcrCheckBox">
-         <property name="toolTip">
-          <string>Enable/disable DC removal.</string>
+        <layout class="QFormLayout" name="pagedemodFormLayout3">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
          </property>
-         <property name="text">
-          <string>DCR</string>
+         <property name="labelAlignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
-         <property name="checked">
-          <bool>true</bool>
+         <property name="horizontalSpacing">
+          <number>10</number>
          </property>
-        </widget>
+         <property name="verticalSpacing">
+          <number>5</number>
+         </property>
+         <property name="leftMargin">
+          <number>5</number>
+         </property>
+         <property name="rightMargin">
+          <number>5</number>
+         </property>
+         <property name="bottomMargin">
+          <number>5</number>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="pllBwLabel">
+           <property name="text">
+            <string>PLL</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="pllBwSelector">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="toolTip">
+		   <string>Carrier tracking PLL. Weak, noisy or fading signals may
+benefit from a slower PLL. A slower PLL will take longer
+to react to changes in the carrier frequency however.</string>
+           </property>
+           <property name="statusTip">
+            <string/>
+           </property>
+           <property name="currentIndex">
+            <number>1</number>
+           </property>
+           <item>
+            <property name="text">
+             <string>Fast</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Medium</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Slow</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+	 <item row="1" column="0">
+          <widget class="QCheckBox" name="syncdcrCheckBox">
+           <property name="toolTip">
+            <string>Enable/disable DC removal.</string>
+           </property>
+           <property name="text">
+            <string>DCR</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>

--- a/src/qtgui/demod_options.ui
+++ b/src/qtgui/demod_options.ui
@@ -260,6 +260,23 @@ For digital modes it is best to switch it off.</string>
        </layout>
       </widget>
      </widget>
+     <widget class="QWidget" name="demodAmSyncOpt">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <widget class="QCheckBox" name="syncdcrCheckBox">
+         <property name="toolTip">
+          <string>Enable/disable DC removal.</string>
+         </property>
+         <property name="text">
+          <string>DCR</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -41,7 +41,8 @@ static const int filter_preset_table[DockRxOpt::MODE_LAST][3][2] =
     {{    100,   4000}, {   100,  2800}, {   300,  2400}},  // MODE_USB
     {{  -1000,   1000}, {  -250,   250}, {  -100,   100}},  // MODE_CWL
     {{  -1000,   1000}, {  -250,   250}, {  -100,   100}},  // MODE_CWU
-    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}}   // MODE_WFM_STEREO_OIRT
+    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}},  // MODE_WFM_STEREO_OIRT
+    {{ -10000,  10000}, { -5000,  5000}, { -2500,  2500}}   // MODE_AMSYNC
 };
 
 DockRxOpt::DockRxOpt(qint64 filterOffsetRange, QWidget *parent) :
@@ -66,6 +67,7 @@ DockRxOpt::DockRxOpt(qint64 filterOffsetRange, QWidget *parent) :
         ModulationStrings.append("CW-L");
         ModulationStrings.append("CW-U");
         ModulationStrings.append("WFM (oirt)");
+        ModulationStrings.append("AM-Sync");
     }
     ui->modeSelector->addItems(ModulationStrings);
 
@@ -102,6 +104,7 @@ DockRxOpt::DockRxOpt(qint64 filterOffsetRange, QWidget *parent) :
     connect(demodOpt, SIGNAL(fmEmphSelected(double)), this, SLOT(demodOpt_fmEmphSelected(double)));
     connect(demodOpt, SIGNAL(amDcrToggled(bool)), this, SLOT(demodOpt_amDcrToggled(bool)));
     connect(demodOpt, SIGNAL(cwOffsetChanged(int)), this, SLOT(demodOpt_cwOffsetChanged(int)));
+    connect(demodOpt, SIGNAL(amSyncDcrToggled(bool)), this, SLOT(demodOpt_amSyncDcrToggled(bool)));
 
     // AGC options dialog
     agcOpt = new CAgcOptions(this);
@@ -574,6 +577,8 @@ void DockRxOpt::updateDemodOptPage(int demod)
         demodOpt->setCurrentPage(CDemodOptions::PAGE_AM_OPT);
     else if (demod == MODE_CWL || demod == MODE_CWU)
         demodOpt->setCurrentPage(CDemodOptions::PAGE_CW_OPT);
+    else if (demod == MODE_AM_SYNC)
+        demodOpt->setCurrentPage(CDemodOptions::PAGE_AMSYNC_OPT);
     else
         demodOpt->setCurrentPage(CDemodOptions::PAGE_NO_OPT);
 }
@@ -719,6 +724,15 @@ void DockRxOpt::demodOpt_amDcrToggled(bool enabled)
 void DockRxOpt::demodOpt_cwOffsetChanged(int offset)
 {
     emit cwOffsetChanged(offset);
+}
+
+/**
+ * @brief AM-Sync DC removal toggled by user.
+ * @param enabled Whether DCR is enabled or not.
+ */
+void DockRxOpt::demodOpt_amSyncDcrToggled(bool enabled)
+{
+    emit amSyncDcrToggled(enabled);
 }
 
 /** Noise blanker 1 button has been toggled. */

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -105,6 +105,7 @@ DockRxOpt::DockRxOpt(qint64 filterOffsetRange, QWidget *parent) :
     connect(demodOpt, SIGNAL(amDcrToggled(bool)), this, SLOT(demodOpt_amDcrToggled(bool)));
     connect(demodOpt, SIGNAL(cwOffsetChanged(int)), this, SLOT(demodOpt_cwOffsetChanged(int)));
     connect(demodOpt, SIGNAL(amSyncDcrToggled(bool)), this, SLOT(demodOpt_amSyncDcrToggled(bool)));
+    connect(demodOpt, SIGNAL(amSyncPllBwSelected(float)), this, SLOT(demodOpt_amSyncPllBwSelected(float)));
 
     // AGC options dialog
     agcOpt = new CAgcOptions(this);
@@ -733,6 +734,15 @@ void DockRxOpt::demodOpt_cwOffsetChanged(int offset)
 void DockRxOpt::demodOpt_amSyncDcrToggled(bool enabled)
 {
     emit amSyncDcrToggled(enabled);
+}
+
+/**
+ * @brief AM-Sync PLL BW changed by user.
+ * @param pll_bw The new PLL BW.
+ */
+void DockRxOpt::demodOpt_amSyncPllBwSelected(float pll_bw)
+{
+    emit amSyncPllBwSelected(pll_bw);
 }
 
 /** Noise blanker 1 button has been toggled. */

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -75,7 +75,7 @@ public:
         MODE_CWL        = 8, /*!< CW using LSB filter. */
         MODE_CWU        = 9, /*!< CW using USB filter. */
         MODE_WFM_STEREO_OIRT = 10, /*!< Broadcast FM (stereo oirt). */
-        MODE_AM_SYNC    = 11, /*!< Broadcast FM (stereo oirt). */
+        MODE_AM_SYNC    = 11, /*!< Amplitude modulation (synchronous demod). */
         MODE_LAST       = 12
     };
 

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -75,7 +75,8 @@ public:
         MODE_CWL        = 8, /*!< CW using LSB filter. */
         MODE_CWU        = 9, /*!< CW using USB filter. */
         MODE_WFM_STEREO_OIRT = 10, /*!< Broadcast FM (stereo oirt). */
-        MODE_LAST       = 11
+        MODE_AM_SYNC    = 11, /*!< Broadcast FM (stereo oirt). */
+        MODE_LAST       = 12
     };
 
     explicit DockRxOpt(qint64 filterOffsetRange = 90000, QWidget *parent = 0);
@@ -146,6 +147,9 @@ signals:
     /** Signal emitted when AM DCR status is toggled. */
     void amDcrToggled(bool enabled);
 
+    /** Signal emitted when AM-Sync DCR status is toggled. */
+    void amSyncDcrToggled(bool enabled);
+
     /** Signal emitted when baseband gain has changed. Gain is in dB. */
     //void bbGainChanged(float gain);
 
@@ -206,6 +210,7 @@ private slots:
     void demodOpt_fmEmphSelected(double tau);
     void demodOpt_amDcrToggled(bool enabled);
     void demodOpt_cwOffsetChanged(int offset);
+    void demodOpt_amSyncDcrToggled(bool enabled);
 
     // Signals coming from AGC options popup
     void agcOpt_hangToggled(bool checked);

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -150,6 +150,9 @@ signals:
     /** Signal emitted when AM-Sync DCR status is toggled. */
     void amSyncDcrToggled(bool enabled);
 
+    /** Signal emitted when new AM-Sync PLL BW is selected. */
+    void amSyncPllBwSelected(float pll_bw);
+
     /** Signal emitted when baseband gain has changed. Gain is in dB. */
     //void bbGainChanged(float gain);
 
@@ -211,6 +214,7 @@ private slots:
     void demodOpt_amDcrToggled(bool enabled);
     void demodOpt_cwOffsetChanged(int offset);
     void demodOpt_amSyncDcrToggled(bool enabled);
+    void demodOpt_amSyncPllBwSelected(float pll_bw);
 
     // Signals coming from AGC options popup
     void agcOpt_hangToggled(bool checked);

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -50,6 +50,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     demod_ssb = gr::blocks::complex_to_real::make(1);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 5000.0, 75.0e-6);
     demod_am = make_rx_demod_am(PREF_QUAD_RATE, true);
+    demod_amsync = make_rx_demod_amsync(PREF_QUAD_RATE, true);
 
     audio_rr0.reset();
     audio_rr1.reset();
@@ -256,6 +257,11 @@ void nbrx::set_demod(int rx_demod)
         demod = demod_am;
         break;
 
+    case NBRX_DEMOD_AMSYNC:
+        d_demod = NBRX_DEMOD_AMSYNC;
+        demod = demod_amsync;
+        break;
+
     case NBRX_DEMOD_FM:
     default:
         d_demod = NBRX_DEMOD_FM;
@@ -310,4 +316,9 @@ void nbrx::set_fm_deemph(double tau)
 void nbrx::set_am_dcr(bool enabled)
 {
     demod_am->set_dcr(enabled);
+}
+
+void nbrx::set_amsync_dcr(bool enabled)
+{
+    demod_amsync->set_dcr(enabled);
 }

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -50,7 +50,7 @@ nbrx::nbrx(float quad_rate, float audio_rate)
     demod_ssb = gr::blocks::complex_to_real::make(1);
     demod_fm = make_rx_demod_fm(PREF_QUAD_RATE, 5000.0, 75.0e-6);
     demod_am = make_rx_demod_am(PREF_QUAD_RATE, true);
-    demod_amsync = make_rx_demod_amsync(PREF_QUAD_RATE, true);
+    demod_amsync = make_rx_demod_amsync(PREF_QUAD_RATE, true, 0.001);
 
     audio_rr0.reset();
     audio_rr1.reset();
@@ -321,4 +321,9 @@ void nbrx::set_am_dcr(bool enabled)
 void nbrx::set_amsync_dcr(bool enabled)
 {
     demod_amsync->set_dcr(enabled);
+}
+
+void nbrx::set_amsync_pll_bw(float pll_bw)
+{
+    demod_amsync->set_pll_bw(pll_bw);
 }

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -62,7 +62,7 @@ public:
         NBRX_DEMOD_AM   = 1,  /*!< Amplitude modulation. */
         NBRX_DEMOD_FM   = 2,  /*!< Frequency modulation. */
         NBRX_DEMOD_SSB  = 3,  /*!< Single Side Band. */
-        NBRX_DEMOD_AMSYNC = 4, /*!< Amplitude modulation. */
+        NBRX_DEMOD_AMSYNC = 4, /*!< Amplitude modulation (synchronous demod). */
         NBRX_DEMOD_NUM  = 5   /*!< Included for convenience. */
     };
 

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -62,7 +62,8 @@ public:
         NBRX_DEMOD_AM   = 1,  /*!< Amplitude modulation. */
         NBRX_DEMOD_FM   = 2,  /*!< Frequency modulation. */
         NBRX_DEMOD_SSB  = 3,  /*!< Single Side Band. */
-        NBRX_DEMOD_NUM  = 4   /*!< Included for convenience. */
+        NBRX_DEMOD_AMSYNC = 4, /*!< Amplitude modulation. */
+        NBRX_DEMOD_NUM  = 5   /*!< Included for convenience. */
     };
 
 public:
@@ -110,6 +111,10 @@ public:
     bool has_am() { return true; }
     void set_am_dcr(bool enabled);
 
+    /* AM-Sync parameters */
+    bool has_amsync() { return true; }
+    void set_amsync_dcr(bool enabled);
+
 private:
     bool   d_running;          /*!< Whether receiver is running or not. */
     float  d_quad_rate;        /*!< Input sample rate. */
@@ -128,6 +133,7 @@ private:
     gr::blocks::complex_to_real::sptr   demod_ssb;  /*!< SSB demodulator. */
     rx_demod_fm_sptr          demod_fm;   /*!< FM demodulator. */
     rx_demod_am_sptr          demod_am;   /*!< AM demodulator. */
+    rx_demod_amsync_sptr      demod_amsync;   /*!< AM-Sync demodulator. */
     resampler_ff_sptr         audio_rr0;  /*!< Audio resampler. */
     resampler_ff_sptr         audio_rr1;  /*!< Audio resampler. */
 

--- a/src/receivers/nbrx.h
+++ b/src/receivers/nbrx.h
@@ -114,6 +114,7 @@ public:
     /* AM-Sync parameters */
     bool has_amsync() { return true; }
     void set_amsync_dcr(bool enabled);
+    void set_amsync_pll_bw(float pll_bw);
 
 private:
     bool   d_running;          /*!< Whether receiver is running or not. */

--- a/src/receivers/receiver_base.cpp
+++ b/src/receivers/receiver_base.cpp
@@ -144,6 +144,11 @@ void receiver_base_cf::set_amsync_dcr(bool enabled)
     (void) enabled;
 }
 
+void receiver_base_cf::set_amsync_pll_bw(float pll_bw)
+{
+    (void) pll_bw;
+}
+
 void receiver_base_cf::get_rds_data(std::string &outbuff, int &num)
 {
         (void) outbuff;

--- a/src/receivers/receiver_base.cpp
+++ b/src/receivers/receiver_base.cpp
@@ -134,6 +134,16 @@ void receiver_base_cf::set_am_dcr(bool enabled)
     (void) enabled;
 }
 
+bool receiver_base_cf::has_amsync()
+{
+    return false;
+}
+
+void receiver_base_cf::set_amsync_dcr(bool enabled)
+{
+    (void) enabled;
+}
+
 void receiver_base_cf::get_rds_data(std::string &outbuff, int &num)
 {
         (void) outbuff;

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -98,6 +98,7 @@ public:
     /* AM-Sync parameters */
     virtual bool has_amsync();
     virtual void set_amsync_dcr(bool enabled);
+    virtual void set_amsync_pll_bw(float pll_bw);
 
     virtual void get_rds_data(std::string &outbuff, int &num);
     virtual void start_rds_decoder();

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -95,6 +95,10 @@ public:
     virtual bool has_am();
     virtual void set_am_dcr(bool enabled);
 
+    /* AM-Sync parameters */
+    virtual bool has_amsync();
+    virtual void set_amsync_dcr(bool enabled);
+
     virtual void get_rds_data(std::string &outbuff, int &num);
     virtual void start_rds_decoder();
     virtual void stop_rds_decoder();


### PR DESCRIPTION
Forward port and update the patch from #462. I've hopefully fixed the backward compatibility issues in the process.

Also add a patch to make the carrier PLL loop BW configurable. There are three PLL options (fast, medium and slow). The values were chosen by experimentation with challenging shortwave signals, looking at them in a GRC mock up of the detector as well as listening to them in gqrx. Having said that, they are pretty arbitrary so could be fine tuned based on further feedback.

One thing missing from the demodulator API is a callback whenever the frequency is changed. We could use that the reset the PLL. Right now the PLL can take a long time to adjust to a change in frequency, especially on the slow setting.