### PR TITLE
Allow scroll wheel direction to be inverted

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Stereo option for UDP streaming.
        NEW: Script to generate AppImage.
+       NEW: Allow scroll wheel direction to be inverted.
      FIXED: FM de-emphasis causing audio to be 20 dB quieter than it should be.
      FIXED: FM de-emphasis applied incorrectly in WFM stereo receiver.
      FIXED: Update waterfall time resolution when FFT settings are changed.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -198,6 +198,7 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     connect(uiDockInputCtl, SIGNAL(ignoreLimitsChanged(bool)), this, SLOT(setIgnoreLimits(bool)));
     connect(uiDockInputCtl, SIGNAL(antennaSelected(QString)), this, SLOT(setAntenna(QString)));
     connect(uiDockInputCtl, SIGNAL(freqCtrlResetChanged(bool)), this, SLOT(setFreqCtrlReset(bool)));
+    connect(uiDockInputCtl, SIGNAL(invertScrollingChanged(bool)), this, SLOT(setInvertScrolling(bool)));
     connect(uiDockRxOpt, SIGNAL(rxFreqChanged(qint64)), ui->freqCtrl, SLOT(setFrequency(qint64)));
     connect(uiDockRxOpt, SIGNAL(filterOffsetChanged(qint64)), this, SLOT(setFilterOffset(qint64)));
     connect(uiDockRxOpt, SIGNAL(filterOffsetChanged(qint64)), remote, SLOT(setFilterOffset(qint64)));
@@ -981,6 +982,14 @@ void MainWindow::setIgnoreLimits(bool ignore_limits)
 void MainWindow::setFreqCtrlReset(bool enabled)
 {
     ui->freqCtrl->setResetLowerDigits(enabled);
+}
+
+/** Invert scroll wheel direction */
+void MainWindow::setInvertScrolling(bool enabled)
+{
+    ui->freqCtrl->setInvertScrolling(enabled);
+    ui->plotter->setInvertScrolling(enabled);
+    uiDockRxOpt->setInvertScrolling(enabled);
 }
 
 /**

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -982,6 +982,7 @@ void MainWindow::setIgnoreLimits(bool ignore_limits)
 void MainWindow::setFreqCtrlReset(bool enabled)
 {
     ui->freqCtrl->setResetLowerDigits(enabled);
+    uiDockRxOpt->setResetLowerDigits(enabled);
 }
 
 /** Invert scroll wheel direction */

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -142,6 +142,7 @@ private slots:
     void setIqBalance(bool enabled);
     void setIgnoreLimits(bool ignore_limits);
     void setFreqCtrlReset(bool enabled);
+    void setInvertScrolling(bool enabled);
     void selectDemod(QString demod);
     void selectDemod(int index);
     void setFmMaxdev(float max_dev);

--- a/src/qtgui/dockinputctl.cpp
+++ b/src/qtgui/dockinputctl.cpp
@@ -110,6 +110,10 @@ void DockInputCtl::readSettings(QSettings * settings)
     bool_val = settings->value("gui/fctl_reset_digits", true).toBool();
     emit freqCtrlResetChanged(bool_val);
     ui->freqCtrlResetButton->setChecked(bool_val);
+
+    bool_val = settings->value("gui/invert_scrolling", false).toBool();
+    emit invertScrollingChanged(bool_val);
+    ui->invertScrollingButton->setChecked(bool_val);
 }
 
 void DockInputCtl::saveSettings(QSettings * settings)
@@ -171,6 +175,12 @@ void DockInputCtl::saveSettings(QSettings * settings)
         settings->setValue("gui/fctl_reset_digits", false);
     else
         settings->remove("gui/fctl_reset_digits");
+
+    // Remember state of invert scrolling button. Default is unchecked.
+    if (ui->invertScrollingButton->isChecked())
+        settings->setValue("gui/invert_scrolling", true);
+    else
+        settings->remove("gui/invert_scrolling");
 }
 
 void DockInputCtl::readLnbLoFromSettings(QSettings * settings)
@@ -347,6 +357,12 @@ void DockInputCtl::setFreqCtrlReset(bool enabled)
     ui->freqCtrlResetButton->setChecked(enabled);
 }
 
+/** Enable/disable invert scroll wheel direction */
+void DockInputCtl::setInvertScrolling(bool enabled)
+{
+    ui->invertScrollingButton->setChecked(enabled);
+}
+
 /**
  * Set gain stages.
  * @param gain_list A list containing the gain stages for this device.
@@ -500,6 +516,12 @@ void DockInputCtl::on_antSelector_currentIndexChanged(const QString &antenna)
 void DockInputCtl::on_freqCtrlResetButton_toggled(bool checked)
 {
     emit freqCtrlResetChanged(checked);
+}
+
+/** Invert scrolling box has changed */
+void DockInputCtl::on_invertScrollingButton_toggled(bool checked)
+{
+    emit invertScrollingChanged(checked);
 }
 
 /** Remove all widgets from the lists. */

--- a/src/qtgui/dockinputctl.h
+++ b/src/qtgui/dockinputctl.h
@@ -100,6 +100,7 @@ public:
     void    restoreManualGains(void);
 
     void    setFreqCtrlReset(bool enabled);
+    void    setInvertScrolling(bool enabled);
 
 public slots:
     bool    setGain(QString name, double value);
@@ -115,6 +116,7 @@ signals:
     void ignoreLimitsChanged(bool ignore);
     void antennaSelected(QString antenna);
     void freqCtrlResetChanged(bool enabled);
+    void invertScrollingChanged(bool enabled);
 
 public slots:
     void setLnbLo(double freq_mhz);
@@ -129,6 +131,7 @@ private slots:
     void on_ignoreButton_toggled(bool checked);
     void on_antSelector_currentIndexChanged(const QString &antenna);
     void on_freqCtrlResetButton_toggled(bool checked);
+    void on_invertScrollingButton_toggled(bool checked);
 
     void sliderValueChanged(int value);
 

--- a/src/qtgui/dockinputctl.ui
+++ b/src/qtgui/dockinputctl.ui
@@ -232,6 +232,13 @@
      </widget>
     </item>
     <item>
+     <widget class="QCheckBox" name="invertScrollingButton">
+      <property name="text">
+       <string>Invert scroll wheel direction</string>
+      </property>
+     </widget>
+    </item>
+    <item>
      <spacer name="verticalSpacer">
       <property name="orientation">
        <enum>Qt::Vertical</enum>

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -512,6 +512,11 @@ void DockRxOpt::setRxFreqRange(qint64 min_hz, qint64 max_hz)
     ui->freqSpinBox->blockSignals(false);
 }
 
+void DockRxOpt::setInvertScrolling(bool enabled)
+{
+    ui->filterFreq->setInvertScrolling(enabled);
+}
+
 /**
  * @brief Channel filter offset has changed
  * @param freq The new filter offset in Hz

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -347,9 +347,6 @@ void DockRxOpt::readSettings(QSettings *settings)
     int     int_val;
     double  dbl_val;
 
-    bool bool_val = settings->value("gui/fctl_reset_digits", true).toBool();
-    ui->filterFreq->setResetLowerDigits(bool_val);
-
     int_val = settings->value("receiver/cwoffset", 700).toInt(&conv_ok);
     if (conv_ok)
         demodOpt->setCwOffset(int_val);
@@ -510,6 +507,11 @@ void DockRxOpt::setRxFreqRange(qint64 min_hz, qint64 max_hz)
     ui->freqSpinBox->blockSignals(true);
     ui->freqSpinBox->setRange(1.e-3 * (double)min_hz, 1.e-3 * (double)max_hz);
     ui->freqSpinBox->blockSignals(false);
+}
+
+void DockRxOpt::setResetLowerDigits(bool enabled)
+{
+    ui->filterFreq->setResetLowerDigits(enabled);
 }
 
 void DockRxOpt::setInvertScrolling(bool enabled)

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -96,6 +96,8 @@ public:
     void setHwFreq(qint64 freq_hz);
     void setRxFreqRange(qint64 min_hz, qint64 max_hz);
 
+    void setInvertScrolling(bool enabled);
+
     int  currentDemod() const;
     QString currentDemodAsString();
 

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -96,6 +96,7 @@ public:
     void setHwFreq(qint64 freq_hz);
     void setRxFreqRange(qint64 min_hz, qint64 max_hz);
 
+    void setResetLowerDigits(bool enabled);
     void setInvertScrolling(bool enabled);
 
     int  currentDemod() const;

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -65,6 +65,7 @@ CFreqCtrl::CFreqCtrl(QWidget *parent) :
     m_LRMouseFreqSel = false;
     m_ActiveEditDigit = -1;
     m_ResetLowerDigits = true;
+    m_InvertScrolling = false;
     m_UnitsFont = QFont("Arial", 12, QFont::Normal);
     m_DigitFont = QFont("Arial", 12, QFont::Normal);
 
@@ -464,7 +465,8 @@ void CFreqCtrl::mousePressEvent(QMouseEvent *event)
 void CFreqCtrl::wheelEvent(QWheelEvent *event)
 {
     QPoint    pt = event->pos();
-    int       numDegrees = event->delta() / 8;
+    int       delta = m_InvertScrolling ? -event->delta() : event->delta();
+    int       numDegrees = delta / 8;
     int       numSteps = numDegrees / 15;
 
     for (int i = m_DigStart; i < m_NumDigits; i++)

--- a/src/qtgui/freqctrl.h
+++ b/src/qtgui/freqctrl.h
@@ -51,6 +51,11 @@ public:
         m_ResetLowerDigits = reset;
     }
 
+    void setInvertScrolling(bool invert)
+    {
+        m_InvertScrolling = invert;
+    }
+
 signals:
     void    newFrequency(qint64 freq); // emitted when frequency has changed
 
@@ -87,6 +92,7 @@ private:
 
     bool        m_ResetLowerDigits; /* If TRUE digits below the active one will be reset to 0
                                      *  when the active digit is incremented or decremented. */
+    bool        m_InvertScrolling;
 
     int         m_FirstEditableDigit;
     int         m_LastLeadZeroPos;

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -147,6 +147,7 @@ CPlotter::CPlotter(QWidget *parent) : QFrame(parent)
     m_FilterBoxEnabled = true;
     m_CenterLineEnabled = true;
     m_BookmarksEnabled = true;
+    m_InvertScrolling = false;
 
     m_Span = 96000;
     m_SampleFreq = 96000;
@@ -775,7 +776,8 @@ void CPlotter::zoomOnXAxis(float level)
 void CPlotter::wheelEvent(QWheelEvent * event)
 {
     QPoint pt = event->pos();
-    int numDegrees = event->delta() / 8;
+    int delta = m_InvertScrolling? -event->delta() : event->delta();
+    int numDegrees = delta / 8;
     int numSteps = numDegrees / 15;  /** FIXME: Only used for direction **/
 
     /** FIXME: zooming could use some optimisation **/
@@ -783,7 +785,7 @@ void CPlotter::wheelEvent(QWheelEvent * event)
     {
         // Vertical zoom. Wheel down: zoom out, wheel up: zoom in
         // During zoom we try to keep the point (dB or kHz) under the cursor fixed
-        float zoom_fac = event->delta() < 0 ? 1.1 : 0.9;
+        float zoom_fac = delta < 0 ? 1.1 : 0.9;
         float ratio = (float)pt.y() / (float)m_OverlayPixmap.height();
         float db_range = m_PandMaxdB - m_PandMindB;
         float y_range = (float)m_OverlayPixmap.height();
@@ -802,7 +804,7 @@ void CPlotter::wheelEvent(QWheelEvent * event)
     }
     else if (m_CursorCaptured == XAXIS)
     {
-        zoomStepX(event->delta() < 0 ? 1.1 : 0.9, pt.x());
+        zoomStepX(delta < 0 ? 1.1 : 0.9, pt.x());
     }
     else if (event->modifiers() & Qt::ControlModifier)
     {

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -38,6 +38,7 @@ public:
     void setCenterLineEnabled(bool enabled) { m_CenterLineEnabled = enabled; }
     void setTooltipsEnabled(bool enabled) { m_TooltipsEnabled = enabled; }
     void setBookmarksEnabled(bool enabled) { m_BookmarksEnabled = enabled; }
+    void setInvertScrolling(bool enabled) { m_InvertScrolling = enabled; }
 
     void setNewFftData(float *fftData, int size);
     void setNewFftData(float *fftData, float *wfData, int size);
@@ -225,6 +226,7 @@ private:
     bool        m_FilterBoxEnabled;   /*!< Draw filter box. */
     bool        m_TooltipsEnabled;     /*!< Tooltips enabled */
     bool        m_BookmarksEnabled;   /*!< Show/hide bookmarks on spectrum */
+    bool        m_InvertScrolling;
     int         m_DemodHiCutFreq;
     int         m_DemodLowCutFreq;
     int         m_DemodFreqX;		//screen coordinate x position


### PR DESCRIPTION
A "natural scrolling" option, whereby the scrolling direction for the mouse wheel & touchpad is inverted, is becoming more common across multiple platforms, and is now often the default. This option works well for text and web pages, but not for some other widgets like the frequency control and plotter in Gqrx.

The QWheelEvent object provides an [`inverted()`](https://doc.qt.io/qt-5/qwheelevent.html#inverted) method, which indicates whether scrolling is inverted, but the documentation warns:

> Many platforms provide no such information. On such platforms inverted always returns false.

This is the case at least on Ubuntu 18.04 and 20.04. As a result, I think it would be best to add a checkbox to Gqrx to allow the user to invert the scrolling direction, which is what I've done here. The new option appears at the bottom of the "Input controls" panel:

![gqrx-invert-scrolling](https://user-images.githubusercontent.com/583749/83362590-88786180-a360-11ea-99ac-0b163f207d06.png)
