### PR TITLE
Ensure that a minimum filter width is maintained

### DIFF
--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -75,6 +75,8 @@ int gettimeofday(struct timeval * tp, struct timezone * tzp)
 #define FFT_MIN_DB     -160.f
 #define FFT_MAX_DB      0.f
 
+#define FILTER_WIDTH_MIN_HZ 200
+
 // Colors of type QRgb in 0xAARRGGBB format (unsigned int)
 #define PLOTTER_BGD_COLOR           0xFF1F1D1D
 #define PLOTTER_GRID_COLOR          0xFF444242
@@ -383,6 +385,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
             if (m_GrabPosition != 0)
             {
                 m_DemodLowCutFreq = freqFromX(pt.x() - m_GrabPosition ) - m_DemodCenterFreq;
+                m_DemodLowCutFreq = std::min(m_DemodLowCutFreq, m_DemodHiCutFreq - FILTER_WIDTH_MIN_HZ);
                 m_DemodLowCutFreq = roundFreq(m_DemodLowCutFreq, m_FilterClickResolution);
 
                 if (m_symetric && (event->buttons() & Qt::LeftButton))  // symetric adjustment
@@ -418,6 +421,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
             if (m_GrabPosition != 0)
             {
                 m_DemodHiCutFreq = freqFromX( pt.x()-m_GrabPosition ) - m_DemodCenterFreq;
+                m_DemodHiCutFreq = std::max(m_DemodHiCutFreq, m_DemodLowCutFreq + FILTER_WIDTH_MIN_HZ);
                 m_DemodHiCutFreq = roundFreq(m_DemodHiCutFreq, m_FilterClickResolution);
 
                 if (m_symetric && (event->buttons() & Qt::LeftButton)) // symetric adjustment


### PR DESCRIPTION
When dragging the "Low cut" and "High cut" frequencies in the plotter, it is easy to accidentally drag the high cut frequency below the low cut frequency (or vice versa), which causes the receive flowgraph to crash:
```
sched: <block fir_filter_blk<IN_T,OUT_T,TAP_T> (14)> is requesting more input data
  than we can provide.
  ninput_items_required = 11570
  max_possible_items_available = 8191
  If this is a filter, consider reducing the number of taps.
```
To recover from this situation, it is necessary to correct the filter frequencies, then stop & restart the DSP.

To avoid this problem I've added bounds checks to ensure that the two frequencies always remain at least 200 Hz apart. This matches the minimum bandwidth of the CW demodulator.