### PR TITLE
Switch from boost::bind to std::bind

### DIFF
--- a/src/dsp/rds/parser_impl.cc
+++ b/src/dsp/rds/parser_impl.cc
@@ -40,7 +40,7 @@ parser_impl::parser_impl(bool log, bool debug, unsigned char pty_locale)
 	pty_locale(pty_locale)
 {
 	message_port_register_in(pmt::mp("in"));
-	set_msg_handler(pmt::mp("in"), boost::bind(&parser_impl::parse, this, boost::placeholders::_1));
+	set_msg_handler(pmt::mp("in"), std::bind(&parser_impl::parse, this, std::placeholders::_1));
 	message_port_register_out(pmt::mp("out"));
 	reset();
 }

--- a/src/dsp/rx_rds.cpp
+++ b/src/dsp/rx_rds.cpp
@@ -97,7 +97,7 @@ rx_rds_store::rx_rds_store() : gr::block ("rx_rds_store",
                                 gr::io_signature::make (0, 0, 0))
 {
         message_port_register_in(pmt::mp("store"));
-        set_msg_handler(pmt::mp("store"), boost::bind(&rx_rds_store::store, this, boost::placeholders::_1));
+        set_msg_handler(pmt::mp("store"), std::bind(&rx_rds_store::store, this, std::placeholders::_1));
         d_messages.set_capacity(100);
 }
 


### PR DESCRIPTION
#811 broke the Travis CI build (https://travis-ci.org/github/csete/gqrx/builds/733464745) because `boost::placeholders` does not exist in Boost <1.60. Switching to `std::bind` and `std::placeholders` resolves the problem (https://travis-ci.org/github/argilo/gqrx/builds/735583345), and I've opened an upstream pull request for this: https://github.com/bastibl/gr-rds/pull/35.

RDS still works correctly in Gqrx after this change.