### PR TITLE
Fix Qt deprecation warnings

### DIFF
--- a/src/qtgui/bookmarks.cpp
+++ b/src/qtgui/bookmarks.cpp
@@ -212,9 +212,9 @@ QList<BookmarkInfo> Bookmarks::getBookmarksInRange(qint64 low, qint64 high)
 {
     BookmarkInfo info;
     info.frequency=low;
-    QList<BookmarkInfo>::const_iterator lb = qLowerBound(m_BookmarkList, info);
+    QList<BookmarkInfo>::const_iterator lb = std::lower_bound(m_BookmarkList.begin(), m_BookmarkList.end(), info);
     info.frequency=high;
-    QList<BookmarkInfo>::const_iterator ub = qUpperBound(m_BookmarkList, info);
+    QList<BookmarkInfo>::const_iterator ub = std::upper_bound(m_BookmarkList.begin(), m_BookmarkList.end(), info);
 
     QList<BookmarkInfo> found;
 

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1281,7 +1281,7 @@ void CPlotter::drawOverlay()
 #define VER_MARGIN 5
 
     // X and Y axis areas
-    m_YAxisWidth = metrics.width("XXXX") + 2 * HOR_MARGIN;
+    m_YAxisWidth = metrics.boundingRect("XXXX").width() + 2 * HOR_MARGIN;
     m_XAxisYCenter = h - metrics.height()/2;
     int xAxisHeight = metrics.height() + 2 * VER_MARGIN;
     int xAxisTop = h - xAxisHeight;
@@ -1365,7 +1365,7 @@ void CPlotter::drawOverlay()
     QString label;
     label.setNum(float((StartFreq + m_Span) / m_FreqUnits), 'f', m_FreqDigits);
     calcDivSize(StartFreq, StartFreq + m_Span,
-                qMin(w/(metrics.width(label) + metrics.width("O")), HORZ_DIVS_MAX),
+                qMin(w/(metrics.boundingRect(label).width() + metrics.boundingRect("O").width()), HORZ_DIVS_MAX),
                 m_StartFreqAdj, m_FreqPerDiv, m_HorDivs);
     pixperdiv = (float)w * (float) m_FreqPerDiv / (float) m_Span;
     adjoffset = pixperdiv * float (m_StartFreqAdj - StartFreq) / (float) m_FreqPerDiv;
@@ -1383,7 +1383,7 @@ void CPlotter::drawOverlay()
     painter.setPen(QColor(PLOTTER_TEXT_COLOR));
     for (int i = 0; i <= m_HorDivs; i++)
     {
-        int tw = metrics.width(m_HDivText[i]);
+        int tw = metrics.boundingRect(m_HDivText[i]).width();
         x = (int)((float)i*pixperdiv + adjoffset);
         if (x > m_YAxisWidth)
         {
@@ -1422,7 +1422,7 @@ void CPlotter::drawOverlay()
 
     // draw amplitude values (y axis)
     int dB = m_PandMaxdB;
-    m_YAxisWidth = metrics.width("-120 ");
+    m_YAxisWidth = metrics.boundingRect("-120 ").width();
     painter.setPen(QColor(PLOTTER_TEXT_COLOR));
     for (int i = 0; i < m_VerDivs; i++)
     {

--- a/src/qtgui/qtcolorpicker.cpp
+++ b/src/qtgui/qtcolorpicker.cpp
@@ -888,12 +888,10 @@ void ColorPickerPopup::regenerateGrid()
 */
 void ColorPickerPopup::getColorFromDialog()
 {
-    bool ok;
-    QRgb rgb = QColorDialog::getRgba(lastSel.rgba(), &ok, parentWidget());
-    if (!ok)
+    QColor col = QColorDialog::getColor(lastSel.rgba(), parentWidget());
+    if (!col.isValid())
 	return;
 
-    QColor col = QColor::fromRgba(rgb);
     insertColor(col, tr("Custom"), -1);
     lastSel = col;
     emit selected(col);


### PR DESCRIPTION
#801 prompted me to check for other QT deprecation warnings, which I did with `-DQT_DISABLE_DEPRECATED_BEFORE=0x051500`. Here I've corrected everything that was identified. The bookmarks, plotter and color picker all appear to be working correctly after these changes.