### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To compile gqrx from source you need the following dependencies:
     - HackRF Jawbreaker driver from http://greatscottgadgets.com/hackrf/
     - Airspy driver from https://github.com/airspy/host
     - SoapySDR from https://github.com/pothosware/SoapySDR
-    - RFSpace driver is bult in
+    - RFSpace driver is built in
 - gnuradio-osmosdr from http://cgit.osmocom.org/cgit/gr-osmosdr/
 - pulseaudio or portaudio (Linux only and optional)
 - Qt 5 with the following components:

--- a/appimage.sh
+++ b/appimage.sh
@@ -4,16 +4,16 @@
 #
 # Options:
 #   * -u will upload your AppImage file after success to github under 
-#      "continous builds"  
+#      "continuous builds"  
 #
 # Requirements:
 #   * VERSION as an ENV var, if not detected will use actual github
 #     version + commit info
-#   * This must be run after a successfuly build, and need to set the
+#   * This must be run after a successfully build, and need to set the
 #     APP var below to the path of the executable (default is the current
 #     travis build place: build/src/gqrx)
 #   * Must be run on a Linux version as old as the far distro you need to
-#     support, tested successfuly on Ubuntu 14.04 Trusty Tar
+#     support, tested successfully on Ubuntu 14.04 Trusty Tar
 #   * If you plan to use the "-u" option you need to configure some things
 #     for it to work, check this https://github.com/probonopd/uploadtool#usage
 #
@@ -23,7 +23,7 @@
 #the project root will reside after build
 APP="build/src/gqrx"
 
-# No need to tweak below unles you move files on the actual project
+# No need to tweak below unless you move files on the actual project
 DESKTOP="gqrx.desktop"
 ICON="resources/icons/gqrx.svg"
 
@@ -89,7 +89,7 @@ else
 fi
 
 if [ "$1" == "-u" ] ; then
-    # must upload to continous releases
+    # must upload to continuous releases
     # see https://github.com/probonopd/uploadtool#usage for configs to be done
     # for this to work as needed
     wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -263,12 +263,12 @@
      FIXED: Correctly apply initial LNB LO frequency.
      FIXED: Audio output device selection on Mac OS X.
      FIXED: Properly store settings when using Save As function.
-     FIXED: Crash when recording audio whith no rec directory set.
+     FIXED: Crash when recording audio with no rec directory set.
      FIXED: Only allow audio playback while DSP is running.
      FIXED: Ensure DSP is stopped when we exit.
      FIXED: Freeze when switching modes after audio recording.
      FIXED: Toggling "ignore limits" changes frequency.
-     FIXED: Include gqrx.dekstop file.
+     FIXED: Include gqrx.desktop file.
      FIXED: Rename scope.svg to gqrx.svg to avoid confusion.
   IMPROVED: Gqrx can fit on small screens (900x600 pixels).
   IMPROVED: Better color gradient for the waterfall.
@@ -336,7 +336,7 @@
        NEW: Pan & zoom on the pandapter axes.
        NEW: Allow changing FFT size.
      FIXED: Mac OS X compatibility.
-  IMPROVED: Various improvements to the user iterface.
+  IMPROVED: Various improvements to the user interface.
 
 
      2.0.0  Released on July 7, 2012

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -531,7 +531,7 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
             QMessageBox *dialog =
                     new QMessageBox(QMessageBox::Warning, tr("Device Error"),
                                     tr("There was an error configuring the input device.\n"
-                                       "Please make sure that a supported device is atached "
+                                       "Please make sure that a supported device is attached "
                                        "to the computer and restart gqrx."),
                                     QMessageBox::Ok);
             dialog->setModal(true);
@@ -758,7 +758,7 @@ void MainWindow::updateHWFrequencyRange(bool ignore_limits)
 }
 
 /**
- * @brief Update availble frequency range.
+ * @brief Update available frequency range.
  *
  * This function sets the available frequency range based on the hardware
  * frequency range, the selected filter offset and the LNB LO.
@@ -956,11 +956,11 @@ void MainWindow::setIqBalance(bool enabled)
 
 /**
  * @brief Ignore hardware limits.
- * @param ignore_limits Whether harware limits should be ignored or not.
+ * @param ignore_limits Whether hardware limits should be ignored or not.
  *
  * This slot is triggered when the user changes the "Ignore hardware limits"
  * option. It will update the allowed frequency range and also update the
- * current RF center frequency, which may change when we swich from ignore to
+ * current RF center frequency, which may change when we switch from ignore to
  * don't ignore.
  */
 void MainWindow::setIgnoreLimits(bool ignore_limits)
@@ -1350,7 +1350,7 @@ void MainWindow::audioFftTimeout()
     pwr_scale = 1.0 / (fftsize * fftsize);
 
     /** FIXME: move post processing to rx_fft_f **/
-    /* Normalize, calculcate power and shift the FFT */
+    /* Normalize, calculate power and shift the FFT */
     for (i = 0; i < fftsize; i++)
     {
         /* normalize and shift */
@@ -1604,7 +1604,7 @@ void MainWindow::stopIqPlayback()
 
 /**
  * Go to a specific offset in the IQ file.
- * @param seek_pos The byte offset from the begining of the file.
+ * @param seek_pos The byte offset from the beginning of the file.
  */
 void MainWindow::seekIqFile(qint64 seek_pos)
 {
@@ -1698,7 +1698,7 @@ void MainWindow::setFftColor(const QColor color)
     uiDockAudio->setFftColor(color);
 }
 
-/** Enalbe/disable filling the aread below the FFT plot. */
+/** Enable/disable filling the aread below the FFT plot. */
 void MainWindow::setFftFill(bool enable)
 {
     ui->plotter->setFftFill(enable);
@@ -1725,7 +1725,7 @@ void MainWindow::setPeakDetection(bool enabled)
  *
  * This function provides a workaround for the "jerky streaming" that has
  * been experienced using some RTL-SDR dongles when DSP processing is
- * started. The jerkyness disappears when trhe receiver is reconfigured
+ * started. The jerkyness disappears when the receiver is reconfigured
  * by selecting a new demodulator.
  */
 /*void MainWindow::forceRxReconf()
@@ -2275,7 +2275,7 @@ void MainWindow::on_actionAddBookmark_triggered()
     QString tags; // list of tags separated by comma
 
     // Create and show the Dialog for a new Bookmark.
-    // Write the result into variabe 'name'.
+    // Write the result into variable 'name'.
     {
         QDialog dialog(this);
         dialog.setWindowTitle("New bookmark");

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -53,7 +53,7 @@
 #define TARGET_QUAD_RATE 1e6
 
 /**
- * @brief Public contructor.
+ * @brief Public constructor.
  * @param input_device Input device specifier.
  * @param audio_device Audio output device specifier,
  *                     e.g. hw:0 when using ALSA or Portaudio.
@@ -311,7 +311,7 @@ std::vector<std::string> receiver::get_antennas(void) const
     return src->get_antennas();
 }
 
-/** Select antenna conenctor. */
+/** Select antenna connector. */
 void receiver::set_antenna(const std::string &antenna)
 {
     if (!antenna.empty())
@@ -598,7 +598,7 @@ std::vector<std::string> receiver::get_gain_names()
  * @param[out] stop  Upper limit for this gain setting.
  * @param[out] step  The resolution for this gain setting.
  *
- * This function retunrs the range for the requested gain stage.
+ * This function returns the range for the requested gain stage.
  */
 receiver::status receiver::get_gain_range(std::string &name, double *start,
                                           double *stop, double *step) const

--- a/src/applications/gqrx/remote_control.cpp
+++ b/src/applications/gqrx/remote_control.cpp
@@ -264,7 +264,7 @@ void RemoteControl::startRead()
 /*! \brief Slot called when the receiver is tuned to a new frequency.
  *  \param freq The new frequency in Hz.
  *
- * Note that this is the frequency gqrx is receiveing on, i.e. the
+ * Note that this is the frequency gqrx is receiving on, i.e. the
  * hardware frequency + the filter offset.
  */
 void RemoteControl::setNewFrequency(qint64 freq)

--- a/src/applications/gqrx/remote_control.h
+++ b/src/applications/gqrx/remote_control.h
@@ -129,7 +129,7 @@ private:
     float       signal_level;      /*!< Signal level in dBFS */
     double      squelch_level;     /*!< Squelch level in dBFS */
     bool        audio_recorder_status; /*!< Recording enabled */
-    bool        receiver_running;  /*!< Wether the receiver is running or not */
+    bool        receiver_running;  /*!< Whether the receiver is running or not */
     bool        hamlib_compatible;
     gain_list_t gains;             /*!< Possible and current gain settings */
 

--- a/src/applications/gqrx/remote_control_settings.cpp
+++ b/src/applications/gqrx/remote_control_settings.cpp
@@ -57,7 +57,7 @@ int RemoteControlSettings::getPort(void) const
 /*! \brief Add items to the list of allowed hosts.
  *  \param hosts A list with the IP addresses of the allowed hosts.
  *
- * Note that setting the list wil lclear the current contents of the
+ * Note that setting the list will clear the current contents of the
  * list widget.
  */
 void RemoteControlSettings::setHosts(QStringList hosts)

--- a/src/dsp/fm_deemph.cpp
+++ b/src/dsp/fm_deemph.cpp
@@ -33,7 +33,7 @@ fm_deemph_sptr make_fm_deemph(float quad_rate, double tau)
     return gnuradio::get_initial_sptr(new fm_deemph(quad_rate, tau));
 }
 
-static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MIN_IN = 1;  /* Minimum number of input streams. */
 static const int MAX_IN = 1;  /* Maximum number of input streams. */
 static const int MIN_OUT = 1; /* Minimum number of output streams. */
 static const int MAX_OUT = 1; /* Maximum number of output streams. */
@@ -59,7 +59,7 @@ fm_deemph::~fm_deemph ()
 }
 
 /*! \brief Set FM de-emphasis time constant.
- *  \param tau The new time costant.
+ *  \param tau The new time constant.
  */
 void fm_deemph::set_tau(double tau)
 {

--- a/src/dsp/lpf.cpp
+++ b/src/dsp/lpf.cpp
@@ -25,7 +25,7 @@
 #include <gnuradio/filter/firdes.h>
 #include "dsp/lpf.h"
 
-static const int MIN_IN  = 1; /* Mininum number of input streams. */
+static const int MIN_IN  = 1; /* Minimum number of input streams. */
 static const int MAX_IN  = 1; /* Maximum number of input streams. */
 static const int MIN_OUT = 1; /* Minimum number of output streams. */
 static const int MAX_OUT = 1; /* Maximum number of output streams. */

--- a/src/dsp/rds/constants.h
+++ b/src/dsp/rds/constants.h
@@ -122,7 +122,7 @@ const std::string rds_group_acronyms[16]={
 
 /* see page 84, Annex J in the standard */
 const std::string language_codes[44]={
-	"Unkown/not applicable",
+	"Unknown/not applicable",
 	"Albanian",
 	"Breton",
 	"Catalan",

--- a/src/dsp/rds/decoder_impl.cc
+++ b/src/dsp/rds/decoder_impl.cc
@@ -45,7 +45,7 @@ decoder_impl::~decoder_impl() {
 }
 
 
-////////////////////////// HELPER FUNTIONS /////////////////////////
+////////////////////////// HELPER FUNCTIONS /////////////////////////
 
 void decoder_impl::enter_no_sync() {
 	presync = false;

--- a/src/dsp/resampler_ff_old.cpp
+++ b/src/dsp/resampler_ff_old.cpp
@@ -34,7 +34,7 @@ resampler_ffo_sptr make_resampler_ffo(unsigned int input_rate, unsigned int outp
 }
 
 
-static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MIN_IN = 1;  /* Minimum number of input streams. */
 static const int MAX_IN = 1;  /* Maximum number of input streams. */
 static const int MIN_OUT = 1; /* Minimum number of output streams. */
 static const int MAX_OUT = 1; /* Maximum number of output streams. */

--- a/src/dsp/resampler_xx.cpp
+++ b/src/dsp/resampler_xx.cpp
@@ -39,7 +39,7 @@ resampler_cc::resampler_cc(float rate)
           gr::io_signature::make (1, 1, sizeof(gr_complex)),
           gr::io_signature::make (1, 1, sizeof(gr_complex)))
 {
-    /* I ceated this code based on:
+    /* I created this code based on:
        http://gnuradio.squarespace.com/blog/2010/12/6/new-interface-for-pfb_arb_resampler_ccf.html
 
        and blks2.pfb_arb_resampler.py
@@ -100,7 +100,7 @@ resampler_ff::resampler_ff(float rate)
           gr::io_signature::make (1, 1, sizeof(float)),
           gr::io_signature::make (1, 1, sizeof(float)))
 {
-    /* I ceated this code based on:
+    /* I created this code based on:
        http://gnuradio.squarespace.com/blog/2010/12/6/new-interface-for-pfb_arb_resampler_ccf.html
 
        and blks2.pfb_arb_resampler.py

--- a/src/dsp/rx_demod_am.cpp
+++ b/src/dsp/rx_demod_am.cpp
@@ -31,7 +31,7 @@ rx_demod_am_sptr make_rx_demod_am(float quad_rate, bool dcr)
     return gnuradio::get_initial_sptr(new rx_demod_am(quad_rate, dcr));
 }
 
-static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MIN_IN = 1;  /* Minimum number of input streams. */
 static const int MAX_IN = 1;  /* Maximum number of input streams. */
 static const int MIN_OUT = 1; /* Minimum number of output streams. */
 static const int MAX_OUT = 1; /* Maximum number of output streams. */

--- a/src/dsp/rx_demod_fm.cpp
+++ b/src/dsp/rx_demod_fm.cpp
@@ -34,7 +34,7 @@ rx_demod_fm_sptr make_rx_demod_fm(float quad_rate, float max_dev, double tau)
     return gnuradio::get_initial_sptr(new rx_demod_fm(quad_rate, max_dev, tau));
 }
 
-static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MIN_IN = 1;  /* Minimum number of input streams. */
 static const int MAX_IN = 1;  /* Maximum number of input streams. */
 static const int MIN_OUT = 1; /* Minimum number of output streams. */
 static const int MAX_OUT = 1; /* Maximum number of output streams. */
@@ -96,7 +96,7 @@ void rx_demod_fm::set_max_dev(float max_dev)
 }
 
 /*! \brief Set FM de-emphasis time constant.
- *  \param tau The new time costant.
+ *  \param tau The new time constant.
  */
 void rx_demod_fm::set_tau(double tau)
 {

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -128,7 +128,7 @@ void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
  *  \param size The size of data_in.
  *
  * Note that this function does not lock the mutex since the caller, get_fft_data()
- * has alrady locked it.
+ * has already locked it.
  */
 void rx_fft_c::do_fft(unsigned int size)
 {
@@ -318,7 +318,7 @@ void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSiz
  *  \param size The size of data_in.
  *
  * Note that this function does not lock the mutex since the caller, get_fft_data()
- * has alrady locked it.
+ * has already locked it.
  */
 void rx_fft_f::do_fft(unsigned int size)
 {

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -57,7 +57,7 @@ rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize=4096, double quad_rate=0, int w
  *
  * This block is used to compute the FFT of the received spectrum.
  *
- * The samples are collected in a cicular buffer with size FFT_SIZE.
+ * The samples are collected in a circular buffer with size FFT_SIZE.
  * When the GUI asks for a new set of FFT data via get_fft_data() an FFT
  * will be performed on the data stored in the circular buffer - assuming
  * of course that the buffer contains at least fftsize samples.
@@ -123,7 +123,7 @@ rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize=1024, double audio_rate=48000, 
  * This block is used to compute the FFT of the audio spectrum or anything
  * else where real FFT is useful.
  *
- * The samples are collected in a cicular buffer with size FFT_SIZE.
+ * The samples are collected in a circular buffer with size FFT_SIZE.
  * When the GUI asks for a new set of FFT data using get_fft_data() an FFT
  * will be performed on the data stored in the circular buffer - assuming
  * that the buffer contains at least fftsize samples.

--- a/src/dsp/rx_filter.cpp
+++ b/src/dsp/rx_filter.cpp
@@ -26,7 +26,7 @@
 #include <iostream>
 #include "dsp/rx_filter.h"
 
-static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MIN_IN = 1;  /* Minimum number of input streams. */
 static const int MAX_IN = 1;  /* Maximum number of input streams. */
 static const int MIN_OUT = 1; /* Minimum number of output streams. */
 static const int MAX_OUT = 1; /* Maximum number of output streams. */

--- a/src/dsp/rx_rds.cpp
+++ b/src/dsp/rx_rds.cpp
@@ -31,7 +31,7 @@
 #include <stdarg.h>
 #include "dsp/rx_rds.h"
 
-static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MIN_IN = 1;  /* Minimum number of input streams. */
 static const int MAX_IN = 1;  /* Maximum number of input streams. */
 static const int MIN_OUT = 1; /* Minimum number of output streams. */
 static const int MAX_OUT = 1; /* Maximum number of output streams. */

--- a/src/dsp/sniffer_f.cpp
+++ b/src/dsp/sniffer_f.cpp
@@ -85,7 +85,7 @@ int sniffer_f::work(int noutput_items,
 }
 
 
-/*! \brief Get number of samples avaialble for fetching.
+/*! \brief Get number of samples available for fetching.
  *  \return The number of samples in the buffer.
  *
  * This method can be used to read how many samples are currently
@@ -98,7 +98,7 @@ int  sniffer_f::samples_available()
     return d_buffer.size();
 }
 
-/*! \brief Fetch avaialble samples.
+/*! \brief Fetch available samples.
  *  \param out Pointer to allocated memory where the samples will be copied.
  *             Should be at least as big as buffer_size().
  *  \param num The number of sampels returned.

--- a/src/dsp/stereo_demod.cpp
+++ b/src/dsp/stereo_demod.cpp
@@ -36,7 +36,7 @@ stereo_demod_sptr make_stereo_demod(float quad_rate, float audio_rate,
 }
 
 
-static const int MIN_IN  = 1; /* Mininum number of input streams. */
+static const int MIN_IN  = 1; /* Minimum number of input streams. */
 static const int MAX_IN  = 1; /* Maximum number of input streams. */
 static const int MIN_OUT = 2; /* Minimum number of output streams. */
 static const int MAX_OUT = 2; /* Maximum number of output streams. */

--- a/src/interfaces/udp_sink_f.cpp
+++ b/src/interfaces/udp_sink_f.cpp
@@ -38,7 +38,7 @@ udp_sink_f_sptr make_udp_sink_f()
     return gnuradio::get_initial_sptr(new udp_sink_f());
 }
 
-static const int MIN_IN = 2;  /*!< Mininum number of input streams. */
+static const int MIN_IN = 2;  /*!< Minimum number of input streams. */
 static const int MAX_IN = 2;  /*!< Maximum number of input streams. */
 static const int MIN_OUT = 0; /*!< Minimum number of output streams. */
 static const int MAX_OUT = 0; /*!< Maximum number of output streams. */

--- a/src/osxaudio/device_list.cpp
+++ b/src/osxaudio/device_list.cpp
@@ -102,7 +102,7 @@ int osxaudio_device_list::populate_device_list()
     return 0;
 
 error:
-    std::cerr << "An error occured while using OSX audio" << std::endl;
+    std::cerr << "An error occurred while using OSX audio" << std::endl;
     std::cerr << "Error number: " << err << std::endl;
     return err;
 }

--- a/src/osxaudio/device_list.h
+++ b/src/osxaudio/device_list.h
@@ -48,7 +48,7 @@ public:
 
 private:
     unsigned int d_index;    /*! The index of the audio device (unique for each source/sink). */
-    string  d_name;           /*! The name of the audio device. Used when creating souces/sinks. */
+    string  d_name;           /*! The name of the audio device. Used when creating sources/sinks. */
     string  d_description;    /*! The description of the audio device. */
 };
 

--- a/src/portaudio/device_list.cpp
+++ b/src/portaudio/device_list.cpp
@@ -97,7 +97,7 @@ int portaudio_device_list::populate_device_list()
     return 0;
 
 error:
-    std::cerr << "An error occured while using the portaudio stream" << std::endl;
+    std::cerr << "An error occurred while using the portaudio stream" << std::endl;
     std::cerr << "Error number: " << err << std::endl;
     std::cerr << "Error message: " << Pa_GetErrorText(err) << std::endl;
     return err;

--- a/src/portaudio/device_list.h
+++ b/src/portaudio/device_list.h
@@ -48,7 +48,7 @@ public:
 
 private:
     unsigned int d_index;    /*! The index of the audio device (unique for each source/sink). */
-    string  d_name;           /*! The name of the audio device. Used when creating souces/sinks. */
+    string  d_name;           /*! The name of the audio device. Used when creating sources/sinks. */
     string  d_description;    /*! The description of the audio device. */
 };
 

--- a/src/portaudio/portaudio_sink.cpp
+++ b/src/portaudio/portaudio_sink.cpp
@@ -70,7 +70,7 @@ portaudio_sink::portaudio_sink(const string device_name, int audio_rate,
                 device_name.data(), idx);
     }
 
-    // Initialize stream parmaeters
+    // Initialize stream parameters
     d_out_params.device = idx;
     d_out_params.channelCount = 2;
     d_out_params.sampleFormat = paFloat32;

--- a/src/portaudio/portaudio_sink.h
+++ b/src/portaudio/portaudio_sink.h
@@ -62,6 +62,6 @@ private:
     PaStream           *d_stream;
     PaStreamParameters  d_out_params;
     string      d_stream_name;       // Descriptive name of the stream.
-    string      d_app_name;          // Descriptive name of the applcation.
+    string      d_app_name;          // Descriptive name of the application.
     int         d_audio_rate;
 };

--- a/src/pulseaudio/pa_device_list.h
+++ b/src/pulseaudio/pa_device_list.h
@@ -49,7 +49,7 @@ public:
 
 private:
     unsigned int d_index;    /*! The index of the audio device (unique for each source/sink). */
-    string  d_name;          /*! The name of the audio device. Used when creating souces/sinks. */
+    string  d_name;          /*! The name of the audio device. Used when creating sources/sinks. */
     string  d_description;   /*! The description of the audio device. */
 };
 

--- a/src/pulseaudio/pa_sink.h
+++ b/src/pulseaudio/pa_sink.h
@@ -66,7 +66,7 @@ public:
 private:
     pa_simple *d_pasink;    /*! The pulseaudio object. */
     string d_stream_name;   /*! Descriptive name of the stream. */
-    string d_app_name;      /*! Descriptive name of the applcation. */
+    string d_app_name;      /*! Descriptive name of the application. */
     pa_sample_spec d_ss;    /*! pulseaudio sample specification. */
 };
 

--- a/src/pulseaudio/pa_source.h
+++ b/src/pulseaudio/pa_source.h
@@ -63,7 +63,7 @@ public:
 private:
     pa_sample_spec d_ss;           /*! Sample specification. */
     string         d_stream_name;  /*! Descriptive name of the stream. */
-    string         d_app_name;     /*! Descriptive name of the applcation. */
+    string         d_app_name;     /*! Descriptive name of the application. */
     pa_simple     *d_pasrc;        /*! The pulseaudio object. */
 
 };

--- a/src/qtgui/afsk1200win.cpp
+++ b/src/qtgui/afsk1200win.cpp
@@ -138,7 +138,7 @@ void Afsk1200Win::on_actionInfo_triggered()
                           "<p>The Gqrx AFSK1200 decoder taps directly into the SDR signal path "
                           "eliminating the need to mess with virtual or real audio cables. "
                           "It can decode AX.25 packets and displays the decoded packets in a text view.</p>"
-                          "<p>The decoder is based on Qtmm, which is avaialble for Linux, Mac and Windows "
+                          "<p>The decoder is based on Qtmm, which is available for Linux, Mac and Windows "
                           "at <a href='http://qtmm.sf.net/'>http://qtmm.sf.net</a>.</p>"
                           ).arg(VERSION));
 

--- a/src/qtgui/ctk/ctkPimpl.h
+++ b/src/qtgui/ctk/ctkPimpl.h
@@ -141,7 +141,7 @@ double ctkFooObject::property()const
 /*!
  * Define a public class constructor with no argument
  *
- * Also make sure the Pimpl is initalized
+ * Also make sure the Pimpl is initialized
  * \see \ref CorePimpl
  */
 #define CTK_CONSTRUCTOR_NO_ARG_CPP(PUB)  \
@@ -152,7 +152,7 @@ double ctkFooObject::property()const
 /*!
  * Define a public class constructor with one argument
  *
- * Also make sure the Pimpl is initalized
+ * Also make sure the Pimpl is initialized
  * \see \ref CorePimpl
  */
 #define CTK_CONSTRUCTOR_1_ARG_CPP(PUB, _ARG1)   \

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -199,7 +199,7 @@ void DockAudio::on_audioStreamButton_clicked(bool checked)
  *  \param checked Whether recording is ON or OFF.
  *
  * We use the clicked signal instead of the toggled which allows us to change the
- * state programatically using toggle() without triggering the signal.
+ * state programmatically using toggle() without triggering the signal.
  */
 void DockAudio::on_audioRecButton_clicked(bool checked)
 {
@@ -227,7 +227,7 @@ void DockAudio::on_audioRecButton_clicked(bool checked)
  *  \param checked Whether playback is ON or OFF.
  *
  * We use the clicked signal instead of the toggled which allows us to change the
- * state programatically using toggle() without triggering the signal.
+ * state programmatically using toggle() without triggering the signal.
  */
 void DockAudio::on_audioPlayButton_clicked(bool checked)
 {

--- a/src/qtgui/dockbookmarks.cpp
+++ b/src/qtgui/dockbookmarks.cpp
@@ -239,7 +239,7 @@ void DockBookmarks::changeBookmarkTags(int row, int /*column*/)
     BookmarkInfo& bmi = Bookmarks::Get().getBookmark(iIdx);
 
     // Create and show the Dialog for a new Bookmark.
-    // Write the result into variabe 'tags'.
+    // Write the result into variable 'tags'.
     {
         QDialog dialog(this);
         dialog.setWindowTitle("Change Bookmark Tags");

--- a/src/qtgui/dockinputctl.h
+++ b/src/qtgui/dockinputctl.h
@@ -49,7 +49,7 @@ typedef struct
 
 /*! \brief A vector with gain parameters.
  *
- * This data structure is used for transfering
+ * This data structure is used for transferring
  * information about available gain stages.
  */
 typedef std::vector<gain_t> gain_list_t;

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -211,7 +211,7 @@ unsigned int DockRxOpt::filterIdxFromLoHi(int lo, int hi) const
  * @param lo Low cutoff frequency in Hz
  * @param hi High cutoff frequency in Hz.
  *
- * This function will automatically select te "User" preset in the
+ * This function will automatically select the "User" preset in the
  * combo box.
  */
 void DockRxOpt::setFilterParam(int lo, int hi)
@@ -524,7 +524,7 @@ void DockRxOpt::setInvertScrolling(bool enabled)
  * @param freq The new filter offset in Hz
  *
  * This slot is activated when a new filter offset has been selected either
- * usig the mouse or using the keyboard.
+ * using the mouse or using the keyboard.
  */
 void DockRxOpt::on_filterFreq_newFrequency(qint64 freq)
 {

--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -692,7 +692,7 @@ void CIoConfig::inputDeviceSelected(int index)
  * @param text THe new device string
  *
  * This slot is activated when the device string in the text edit box has changed
- * either by the user or programatically. We use this to enable/disable the OK
+ * either by the user or programmatically. We use this to enable/disable the OK
  * button - we allo OK only if there is some text in the text entry.
  */
 void CIoConfig::inputDevstrChanged(const QString &text)

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -389,7 +389,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                 m_DemodLowCutFreq = std::min(m_DemodLowCutFreq, m_DemodHiCutFreq - FILTER_WIDTH_MIN_HZ);
                 m_DemodLowCutFreq = roundFreq(m_DemodLowCutFreq, m_FilterClickResolution);
 
-                if (m_symetric && (event->buttons() & Qt::LeftButton))  // symetric adjustment
+                if (m_symetric && (event->buttons() & Qt::LeftButton))  // symmetric adjustment
                 {
                     m_DemodHiCutFreq = -m_DemodLowCutFreq;
                 }
@@ -403,7 +403,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
             }
             else
             {
-                // save initial grab postion from m_DemodFreqX
+                // save initial grab position from m_DemodFreqX
                 m_GrabPosition = pt.x()-m_DemodLowCutFreqX;
             }
         }
@@ -425,7 +425,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                 m_DemodHiCutFreq = std::max(m_DemodHiCutFreq, m_DemodLowCutFreq + FILTER_WIDTH_MIN_HZ);
                 m_DemodHiCutFreq = roundFreq(m_DemodHiCutFreq, m_FilterClickResolution);
 
-                if (m_symetric && (event->buttons() & Qt::LeftButton)) // symetric adjustment
+                if (m_symetric && (event->buttons() & Qt::LeftButton)) // symmetric adjustment
                 {
                     m_DemodLowCutFreq = -m_DemodHiCutFreq;
                 }
@@ -436,7 +436,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
             }
             else
             {
-                // save initial grab postion from m_DemodFreqX
+                // save initial grab position from m_DemodFreqX
                 m_GrabPosition = pt.x() - m_DemodHiCutFreqX;
             }
         }
@@ -462,7 +462,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
             }
             else
             {
-                // save initial grab postion from m_DemodFreqX
+                // save initial grab position from m_DemodFreqX
                 m_GrabPosition = pt.x() - m_DemodFreqX;
             }
         }
@@ -531,7 +531,7 @@ void CPlotter::clearWaterfall()
 /**
  * @brief Save waterfall to a graphics file
  * @param filename
- * @return TRUE if the save successful, FALSE if an erorr occurred.
+ * @return TRUE if the save successful, FALSE if an error occurred.
  *
  * We assume that frequency strings are up to date
  */
@@ -656,7 +656,7 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
                 // if cursor not captured set demod frequency and start demod box capture
                 emit newDemodFreq(m_DemodCenterFreq, m_DemodCenterFreq - m_CenterFreq);
 
-                // save initial grab postion from m_DemodFreqX
+                // save initial grab position from m_DemodFreqX
                 // setCursor(QCursor(Qt::CrossCursor));
                 m_CursorCaptured = CENTER;
                 m_GrabPosition = 1;
@@ -742,7 +742,7 @@ void CPlotter::zoomStepX(float step, int x)
     // calculate new range shown on FFT
     float new_range = qBound(10.0f, m_Span * step, m_SampleFreq * 10.0f);
 
-    // Frequency where event occured is kept fixed under mouse
+    // Frequency where event occurred is kept fixed under mouse
     float ratio = (float)x / (float)m_OverlayPixmap.width();
     float fixed_hz = freqFromX(x);
     float f_max = fixed_hz + (1.0 - ratio) * new_range;

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -24,7 +24,7 @@
 #include <iostream>
 #include "receivers/nbrx.h"
 
-// NB: Remeber to adjust filter ranges in MainWindow
+// NB: Remember to adjust filter ranges in MainWindow
 #define PREF_QUAD_RATE  96000.f
 
 nbrx_sptr make_nbrx(float quad_rate, float audio_rate)

--- a/src/receivers/receiver_base.cpp
+++ b/src/receivers/receiver_base.cpp
@@ -24,7 +24,7 @@
 #include "receivers/receiver_base.h"
 
 
-static const int MIN_IN = 1;  /* Mininum number of input streams. */
+static const int MIN_IN = 1;  /* Minimum number of input streams. */
 static const int MAX_IN = 1;  /* Maximum number of input streams. */
 static const int MIN_OUT = 2; /* Minimum number of output streams. */
 static const int MAX_OUT = 2; /* Maximum number of output streams. */

--- a/src/receivers/receiver_base.h
+++ b/src/receivers/receiver_base.h
@@ -42,8 +42,8 @@ class receiver_base_cf : public gr::hier_block2
 {
 
 public:
-    /*! \brief Public contructor.
-     *  \param src_name Descriptive name used in the contructor of gr::hier_block2
+    /*! \brief Public constructor.
+     *  \param src_name Descriptive name used in the constructor of gr::hier_block2
      */
     receiver_base_cf(std::string src_name);
     virtual ~receiver_base_cf();


### PR DESCRIPTION
Found via `codespell v2.0.dev0`  
`codespell -q 3 -S *.svg -L ba,dout,inout,symetric,startd,wya`
