### PR TITLE
Decrease minimum size of FFT Settings panel

### DIFF
--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>368</width>
-    <height>433</height>
+    <width>316</width>
+    <height>414</height>
    </size>
   </property>
   <property name="maximumSize">


### PR DESCRIPTION
Fixes #833.

#802 increased the minimum size of the FFT Settings panel to prevent scrollbars from appearing in normal use. This change does not play nicely with screens that are 800 pixels tall, since the Gqrx window is too tall to fit on the screen. Here I've solved the problem by decreasing the minimum size of the FFT Settings window. It's now just large enough to prevent scroll bars from appearing.

@antonblanchard 