### PR TITLE
Catch invalid sample rate exception

### DIFF
--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -337,7 +337,14 @@ double receiver::set_input_rate(double rate)
             * std::numeric_limits<double>::epsilon());
 
     tb->lock();
-    d_input_rate = src->set_sample_rate(rate);
+    try
+    {
+        d_input_rate = src->set_sample_rate(rate);
+    }
+    catch (std::runtime_error &e)
+    {
+        d_input_rate = 0;
+    }
 
     if (d_input_rate == 0)
     {


### PR DESCRIPTION
Fixes #831.

Some gr-osmocom sources throw an exception if an invalid sample rate is passed to `set_sample_rate`. That exception must be caught, since Qt event handlers are not allowed to throw exceptions. Here I'm immediately catching the exception and set `d_input_rate` to zero so that the existing error handling code executes.

Currently this prints an error to the console:
```
Failed to set RX input rate to 3e+06
Your device may not be working properly.
```
It would probably be nice to replace this with an error dialog in the future.