### PR TITLE
Fix loss of precision in xFromFreq and freqFromX

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.13.2: In progress...
+
+     FIXED: Loss of precision in the plotter's frequency axis.
+
+
     2.13.1: Released October 17, 2020
 
      FIXED: Crash when invalid sample rate is specified.

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -1521,12 +1521,12 @@ void CPlotter::makeFrequencyStrs()
     }
 }
 
-// Convert from screen coordinate to frequency
+// Convert from frequency to screen coordinate
 int CPlotter::xFromFreq(qint64 freq)
 {
-    int w = m_OverlayPixmap.width();
-    qint64 StartFreq = m_CenterFreq + m_FftCenter - m_Span/2;
-    int x = (int) w * ((float)freq - StartFreq)/(float)m_Span;
+    qint64 w = m_OverlayPixmap.width();
+    qint64 StartFreq = m_CenterFreq + m_FftCenter - m_Span / 2;
+    int x = (int) (w * (freq - StartFreq) / m_Span);
     if (x < 0)
         return 0;
     if (x > (int)w)
@@ -1537,9 +1537,9 @@ int CPlotter::xFromFreq(qint64 freq)
 // Convert from frequency to screen coordinate
 qint64 CPlotter::freqFromX(int x)
 {
-    int w = m_OverlayPixmap.width();
+    qint64 w = m_OverlayPixmap.width();
     qint64 StartFreq = m_CenterFreq + m_FftCenter - m_Span / 2;
-    qint64 f = (qint64)(StartFreq + (float)m_Span * (float)x / (float)w);
+    qint64 f = StartFreq + m_Span * (qint64) x / w;
     return f;
 }
 


### PR DESCRIPTION
Fixes #818.

At high frequencies (e.g. 5 GHz) and when zoomed in on the frequency axis, there is a noticeable loss of precision when clicking to tune. Also, the red bar showing the currently tuned frequency and the grey area showing the filter edges exhibit a similar loss of precision.

These problems occur because `CPlotter::xFromFreq` and `CPlotter::freqFromX` use single-precision floating-point, which only has 24 bits of precision. I've switched these calculations to use `qint64` instead.

@ly2ss If you have a chance to test this, it would be much appreciated!