### PR TITLE
Replace boost::mutex with std::mutex

### DIFF
--- a/src/dsp/rx_agc_xx.cpp
+++ b/src/dsp/rx_agc_xx.cpp
@@ -74,7 +74,7 @@ int rx_agc_cc::work(int noutput_items,
     const gr_complex *in = (const gr_complex *) input_items[0];
     gr_complex *out = (gr_complex *) output_items[0];
 
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
     d_agc->ProcessData(noutput_items, in, out);
 
     return noutput_items;
@@ -91,7 +91,7 @@ int rx_agc_cc::work(int noutput_items,
 void rx_agc_cc::set_agc_on(bool agc_on)
 {
     if (agc_on != d_agc_on) {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
         d_agc_on = agc_on;
         d_agc->SetParameters(d_agc_on, d_use_hang, d_threshold, d_manual_gain,
                              d_slope, d_decay, d_sample_rate);
@@ -108,7 +108,7 @@ void rx_agc_cc::set_agc_on(bool agc_on)
 void rx_agc_cc::set_sample_rate(double sample_rate)
 {
     if (sample_rate != d_sample_rate) {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
         d_sample_rate = sample_rate;
         d_agc->SetParameters(d_agc_on, d_use_hang, d_threshold, d_manual_gain,
                              d_slope, d_decay, d_sample_rate);
@@ -124,7 +124,7 @@ void rx_agc_cc::set_sample_rate(double sample_rate)
 void rx_agc_cc::set_threshold(int threshold)
 {
     if ((threshold != d_threshold) && (threshold >= -160) && (threshold <= 0)) {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
         d_threshold = threshold;
         d_agc->SetParameters(d_agc_on, d_use_hang, d_threshold, d_manual_gain,
                              d_slope, d_decay, d_sample_rate);
@@ -142,7 +142,7 @@ void rx_agc_cc::set_threshold(int threshold)
 void rx_agc_cc::set_manual_gain(int gain)
 {
     if ((gain != d_manual_gain) && (gain >= 0) && (gain <= 100)) {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
         d_manual_gain = gain;
         d_agc->SetParameters(d_agc_on, d_use_hang, d_threshold, d_manual_gain,
                              d_slope, d_decay, d_sample_rate);
@@ -158,7 +158,7 @@ void rx_agc_cc::set_manual_gain(int gain)
 void rx_agc_cc::set_slope(int slope)
 {
     if ((slope != d_slope) && (slope >= 0) && (slope <= 10)) {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
         d_slope = slope;
         d_agc->SetParameters(d_agc_on, d_use_hang, d_threshold, d_manual_gain,
                              d_slope, d_decay, d_sample_rate);
@@ -172,7 +172,7 @@ void rx_agc_cc::set_slope(int slope)
 void rx_agc_cc::set_decay(int decay)
 {
     if ((decay != d_decay) && (decay >= 20) && (decay <= 5000)) {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
         d_decay = decay;
         d_agc->SetParameters(d_agc_on, d_use_hang, d_threshold, d_manual_gain,
                              d_slope, d_decay, d_sample_rate);
@@ -186,7 +186,7 @@ void rx_agc_cc::set_decay(int decay)
 void rx_agc_cc::set_use_hang(bool use_hang)
 {
     if (use_hang != d_use_hang) {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
         d_use_hang = use_hang;
         d_agc->SetParameters(d_agc_on, d_use_hang, d_threshold, d_manual_gain,
                              d_slope, d_decay, d_sample_rate);

--- a/src/dsp/rx_agc_xx.h
+++ b/src/dsp/rx_agc_xx.h
@@ -23,9 +23,9 @@
 #ifndef RX_AGC_XX_H
 #define RX_AGC_XX_H
 
+#include <mutex>
 #include <gnuradio/sync_block.h>
 #include <gnuradio/gr_complex.h>
-#include <boost/thread/mutex.hpp>
 #include <dsp/agc_impl.h>
 
 class rx_agc_cc;
@@ -87,7 +87,7 @@ public:
 
 private:
     CAgc           *d_agc;
-    boost::mutex    d_mutex;  /*! Used to lock internal data while processing or setting parameters. */
+    std::mutex      d_mutex;  /*! Used to lock internal data while processing or setting parameters. */
 
     bool            d_agc_on;        /*! Current AGC status (true/false). */
     double          d_sample_rate;   /*! Current sample rate. */

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -83,7 +83,7 @@ int rx_fft_c::work(int noutput_items,
     (void) output_items;
 
     /* just throw new samples into the buffer */
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
     for (i = 0; i < noutput_items; i++)
     {
         d_cbuf.push_back(in[i]);
@@ -99,7 +99,7 @@ int rx_fft_c::work(int noutput_items,
  */
 void rx_fft_c::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSize)
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     if (d_cbuf.size() < d_fftsize)
     {
@@ -151,7 +151,7 @@ void rx_fft_c::do_fft(unsigned int size)
 /*! \brief Update circular buffer and FFT object. */
 void rx_fft_c::set_params()
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     /* clear and resize circular buffer */
     d_cbuf.clear();
@@ -274,7 +274,7 @@ int rx_fft_f::work(int noutput_items,
     (void) output_items;
 
     /* just throw new samples into the buffer */
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
     for (i = 0; i < noutput_items; i++)
     {
         d_cbuf.push_back(in[i]);
@@ -289,7 +289,7 @@ int rx_fft_f::work(int noutput_items,
  */
 void rx_fft_f::get_fft_data(std::complex<float>* fftPoints, unsigned int &fftSize)
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     if (d_cbuf.size() < d_fftsize)
     {
@@ -347,7 +347,7 @@ void rx_fft_f::set_fft_size(unsigned int fftsize)
 {
     if (fftsize != d_fftsize)
     {
-        boost::mutex::scoped_lock lock(d_mutex);
+        std::lock_guard<std::mutex> lock(d_mutex);
 
         d_fftsize = fftsize;
 

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -23,11 +23,11 @@
 #ifndef RX_FFT_H
 #define RX_FFT_H
 
+#include <mutex>
 #include <gnuradio/sync_block.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/filter/firdes.h>       /* contains enum win_type */
 #include <gnuradio/gr_complex.h>
-#include <boost/thread/mutex.hpp>
 #include <boost/circular_buffer.hpp>
 #include <chrono>
 
@@ -92,7 +92,7 @@ private:
     double       d_quadrate;
     int          d_wintype;   /*! Current window type. */
 
-    boost::mutex d_mutex;  /*! Used to lock FFT output buffer. */
+    std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */
 
     gr::fft::fft_complex    *d_fft;    /*! FFT object. */
     std::vector<float>  d_window; /*! FFT window taps. */
@@ -157,7 +157,7 @@ private:
     double       d_audiorate;
     int          d_wintype;   /*! Current window type. */
 
-    boost::mutex d_mutex;  /*! Used to lock FFT output buffer. */
+    std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */
 
     gr::fft::fft_complex    *d_fft;    /*! FFT object. */
     std::vector<float>  d_window; /*! FFT window taps. */

--- a/src/dsp/rx_noise_blanker_cc.cpp
+++ b/src/dsp/rx_noise_blanker_cc.cpp
@@ -73,7 +73,7 @@ int rx_nb_cc::work(int noutput_items,
     gr_complex *out = (gr_complex *) output_items[0];
     int i;
 
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     // copy data into output buffer then perform the processing on that buffer
     for (i = 0; i < noutput_items; i++)

--- a/src/dsp/rx_noise_blanker_cc.h
+++ b/src/dsp/rx_noise_blanker_cc.h
@@ -23,9 +23,9 @@
 #ifndef RX_NB_CC_H
 #define RX_NB_CC_H
 
+#include <mutex>
 #include <gnuradio/sync_block.h>
 #include <gnuradio/gr_complex.h>
-#include <boost/thread/mutex.hpp>
 
 class rx_nb_cc;
 
@@ -78,7 +78,7 @@ private:
     void process_nb2(gr_complex *buf, int num);
 
 private:
-    boost::mutex  d_mutex;  /*! Used to lock internal data while processing or setting parameters. */
+    std::mutex d_mutex;     /*! Used to lock internal data while processing or setting parameters. */
 
     bool   d_nb1_on;        /*! Current NB1 status (true/false). */
     bool   d_nb2_on;        /*! Current NB2 status (true/false). */

--- a/src/dsp/rx_rds.cpp
+++ b/src/dsp/rx_rds.cpp
@@ -108,14 +108,14 @@ rx_rds_store::~rx_rds_store ()
 
 void rx_rds_store::store(pmt::pmt_t msg)
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
     d_messages.push_back(msg);
 
 }
 
 void rx_rds_store::get_message(std::string &out, int &type)
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     if (d_messages.size()>0) {
         pmt::pmt_t msg=d_messages.front();

--- a/src/dsp/rx_rds.h
+++ b/src/dsp/rx_rds.h
@@ -23,6 +23,7 @@
 #ifndef RX_RDS_H
 #define RX_RDS_H
 
+#include <mutex>
 #include <gnuradio/hier_block2.h>
 
 #if GNURADIO_VERSION < 0x030800
@@ -69,7 +70,7 @@ public:
 private:
     void store(pmt::pmt_t msg);
 
-    boost::mutex d_mutex;
+    std::mutex d_mutex;
     boost::circular_buffer<pmt::pmt_t> d_messages;
 
 };

--- a/src/dsp/sniffer_f.cpp
+++ b/src/dsp/sniffer_f.cpp
@@ -74,7 +74,7 @@ int sniffer_f::work(int noutput_items,
 
     (void) output_items;
 
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     /* dump new samples into the buffer */
     for (i = 0; i < noutput_items; i++) {
@@ -93,7 +93,7 @@ int sniffer_f::work(int noutput_items,
  */
 int  sniffer_f::samples_available()
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     return d_buffer.size();
 }
@@ -105,7 +105,7 @@ int  sniffer_f::samples_available()
  */
 void sniffer_f::get_samples(float * out, unsigned int &num)
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     if (d_buffer.size() < d_minsamp) {
         /* not enough samples in buffer */
@@ -127,7 +127,7 @@ void sniffer_f::get_samples(float * out, unsigned int &num)
  */
 void sniffer_f::set_buffer_size(int newsize)
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     //d_buffer.clear();
     d_buffer.set_capacity(newsize);
@@ -141,7 +141,7 @@ void sniffer_f::set_buffer_size(int newsize)
  */
 int  sniffer_f::buffer_size()
 {
-    boost::mutex::scoped_lock lock(d_mutex);
+    std::lock_guard<std::mutex> lock(d_mutex);
 
     return d_buffer.capacity();
 }

--- a/src/dsp/sniffer_f.h
+++ b/src/dsp/sniffer_f.h
@@ -23,8 +23,8 @@
 #ifndef SNIFFER_F_H
 #define SNIFFER_F_H
 
+#include <mutex>
 #include <gnuradio/sync_block.h>
-#include <boost/thread/mutex.hpp>
 #include <boost/circular_buffer.hpp>
 
 
@@ -80,7 +80,7 @@ public:
 
 private:
 
-    boost::mutex d_mutex;                   /*! Used to prevent concurrent access to buffer. */
+    std::mutex d_mutex;                     /*! Used to prevent concurrent access to buffer. */
     boost::circular_buffer<float> d_buffer; /*! buffer to accumulate samples. */
     unsigned int d_minsamp;                 /*! smallest number of samples we want to return. */
 


### PR DESCRIPTION
`std::mutex` is available since C++11. By using it, Gqrx's dependence on Boost is reduced.