### PR TITLE
Adjust sizes to fit screen height of 768 pixels

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -5,6 +5,7 @@
        NEW: Print UDP configuration.
        NEW: Viridis color map.
      FIXED: Loss of precision in the plotter's frequency axis.
+     FIXED: Usability on smaller screen sizes.
 
 
     2.13.1: Released October 17, 2020

--- a/src/qtgui/dockaudio.ui
+++ b/src/qtgui/dockaudio.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>220</width>
+    <width>270</width>
     <height>200</height>
    </rect>
   </property>
@@ -18,8 +18,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>220</width>
-    <height>200</height>
+    <width>270</width>
+    <height>195</height>
    </size>
   </property>
   <property name="windowIcon">
@@ -74,7 +74,7 @@
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="spacing">
-       <number>6</number>
+       <number>5</number>
       </property>
       <item>
        <widget class="QLabel" name="audioGainLabel">

--- a/src/qtgui/dockfft.ui
+++ b/src/qtgui/dockfft.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>368</width>
-    <height>433</height>
+    <height>444</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,8 +18,8 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>316</width>
-    <height>414</height>
+    <width>327</width>
+    <height>200</height>
    </size>
   </property>
   <property name="maximumSize">
@@ -71,8 +71,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>348</width>
-         <height>487</height>
+         <width>350</width>
+         <height>407</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -109,7 +109,7 @@
            <number>0</number>
           </property>
           <property name="spacing">
-           <number>6</number>
+           <number>5</number>
           </property>
           <item row="0" column="2" colspan="2">
            <widget class="QLabel" name="fftRbwLabel">

--- a/src/qtgui/dockinputctl.ui
+++ b/src/qtgui/dockinputctl.ui
@@ -32,7 +32,7 @@
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
     <property name="spacing">
-     <number>6</number>
+     <number>5</number>
     </property>
     <property name="leftMargin">
      <number>5</number>


### PR DESCRIPTION
Fixes #833.

#802 increased the minimum height of the FFT Settings window, which increased the minimum height of the entire Gqrx window to the point where it did not work well on small screens. I made the minimum size a bit smaller in #834, but it's still not small enough to work all 800-pixel screens, and doesn't work at all with 768-pixel screens. To fix this, I've set the minimum height of the FFT Settings window back to its original value of 200.

I also increased the minimum width of the FFT Settings window to prevent a horizontal scroll bar from appearing (which wastes vertical space), and reduced the spacing between elements from 6 to 5 in the few places where it wasn't already 5.