### PR TITLE
Fix division by zero in width calculations

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.13.3: In progress...
+
+     FIXED: Crash when waterfall height is set to 100%.
+
+
     2.13.2: Released October 24, 2020
 
        NEW: Preliminary support for GNU Radio 3.9.

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -749,7 +749,7 @@ void CPlotter::zoomStepX(float step, int x)
     float new_range = qBound(10.0f, m_Span * step, m_SampleFreq * 10.0f);
 
     // Frequency where event occurred is kept fixed under mouse
-    float ratio = (float)x / (float)m_OverlayPixmap.width();
+    float ratio = (float)x / (float)width();
     float fixed_hz = freqFromX(x);
     float f_max = fixed_hz + (1.0 - ratio) * new_range;
     float f_min = f_max - new_range;
@@ -1529,20 +1529,20 @@ void CPlotter::makeFrequencyStrs()
 // Convert from frequency to screen coordinate
 int CPlotter::xFromFreq(qint64 freq)
 {
-    qint64 w = m_OverlayPixmap.width();
+    qint64 w = width();
     qint64 StartFreq = m_CenterFreq + m_FftCenter - m_Span / 2;
     int x = (int) (w * (freq - StartFreq) / m_Span);
     if (x < 0)
         return 0;
     if (x > (int)w)
-        return m_OverlayPixmap.width();
+        return w;
     return x;
 }
 
 // Convert from frequency to screen coordinate
 qint64 CPlotter::freqFromX(int x)
 {
-    qint64 w = m_OverlayPixmap.width();
+    qint64 w = width();
     qint64 StartFreq = m_CenterFreq + m_FftCenter - m_Span / 2;
     qint64 f = StartFreq + m_Span * (qint64) x / w;
     return f;


### PR DESCRIPTION
Fixes #846.

If the Panadapter-Waterfall slider (in the "FFT Settings" panel or the audio FFT options dialog) is set such that the waterfall occupies 100% of the display area, then crashes occur due to division by zero in several places where the width of the panadapter is used. (In these cases, the panadapter is null, so `m_OverlayPixmap.width()` returns zero.)

Crashes occur in the following situations:

* hovering over the RF waterfall
* clicking on the audio waterfall
* adjusting the "Freq zoom" slider

To fix this problem, I've changed these calculations to use the width of the plotter instead.