### PR TITLE
Replace Boost.Program_options with QCommandLineParser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ math(EXPR GNURADIO_BCD_VERSION
 add_definitions(-DGNURADIO_VERSION=${GNURADIO_BCD_VERSION})
 
 if(Gnuradio_VERSION VERSION_LESS "3.8")
-    find_package(Boost COMPONENTS system program_options REQUIRED)
+    find_package(Boost COMPONENTS system REQUIRED)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")

--- a/gqrx.pro
+++ b/gqrx.pro
@@ -293,12 +293,12 @@ greaterThan(GNURADIO_VERSION_MINOR, 7) {
 INCPATH += src/
 
 unix:!macx {
-    LIBS += -lboost_system$$BOOST_SUFFIX -lboost_program_options$$BOOST_SUFFIX
+    LIBS += -lboost_system$$BOOST_SUFFIX
     LIBS += -lrt  # need to include on some distros
 }
 
 macx {
-    LIBS += -lboost_system-mt -lboost_program_options-mt
+    LIBS += -lboost_system-mt
 }
 
 OTHER_FILES += \

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.13.3: In progress...
 
      FIXED: Crash when waterfall height is set to 100%.
+  IMPROVED: Remove Boost.Program_options dependency.
 
 
     2.13.2: Released October 24, 2020


### PR DESCRIPTION
QCommandLineParser is available since Qt 5.2. It's more convenient than Boost.Program_options since it produces QStrings directly. Switching to it also removes one of the few remaining usages of Boost.

After this change, all the options work as before. Here's what the help message looks like:
```
Usage: gqrx [options]
Gqrx software defined radio receiver v2.13.2-2-gdf7d3a70d8-dirty

Options:
  -h, --help           Displays this help.
  -s, --style <style>  Use the given style (fusion, windows)
  -l, --list           List existing configurations
  -c, --conf <file>    Start with this config file
  -e, --edit           Edit the config file before using it
  -r, --reset          Reset configuration file
```