### PR TITLE
Fix crash when time span is set and waterfall height is set to 0%

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -2,6 +2,7 @@
     2.13.4: In progress...
 
        NEW: Added man page for use by distributions.
+     FIXED: Crash when time span is set and waterfall height is set to 0%.
   IMPROVED: Removed Boost.Format dependency.
 
 

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -877,7 +877,7 @@ void CPlotter::resizeEvent(QResizeEvent* )
 
         m_PeakHoldValid = false;
 
-        if (wf_span > 0)
+        if (wf_span > 0 && height > 0)
             msec_per_wfline = wf_span / height;
         memset(m_wfbuf, 255, MAX_SCREENSIZE);
     }


### PR DESCRIPTION
Fixes #852.

To avoid division by zero, `height` should be checked before calculating `msec_per_wfline`. This mirrors the logic that is used in `setWaterfallSpan`:

https://github.com/csete/gqrx/blob/46b5578875051e1ef83b7b46e32230b7220df32c/src/qtgui/plotter.cpp#L525-L526