### PR TITLE
Update to GNU Radio 3.9's FFT API

### DIFF
--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -49,7 +49,11 @@ rx_fft_c::rx_fft_c(unsigned int fftsize, double quad_rate, int wintype)
 {
 
     /* create FFT object */
+#if GNURADIO_VERSION < 0x030900
     d_fft = new gr::fft::fft_complex(d_fftsize, true);
+#else
+    d_fft = new gr::fft::fft_complex_fwd(d_fftsize);
+#endif
 
     /* allocate circular buffer */
     d_cbuf.set_capacity(d_fftsize + d_quadrate);
@@ -164,7 +168,11 @@ void rx_fft_c::set_params()
 
     /* reset FFT object (also reset FFTW plan) */
     delete d_fft;
-    d_fft = new gr::fft::fft_complex (d_fftsize, true);
+#if GNURADIO_VERSION < 0x030900
+    d_fft = new gr::fft::fft_complex(d_fftsize, true);
+#else
+    d_fft = new gr::fft::fft_complex_fwd(d_fftsize);
+#endif
 }
 
 /*! \brief Set new FFT size. */
@@ -242,7 +250,11 @@ rx_fft_f::rx_fft_f(unsigned int fftsize, double audio_rate, int wintype)
 {
 
     /* create FFT object */
+#if GNURADIO_VERSION < 0x030900
     d_fft = new gr::fft::fft_complex(d_fftsize, true);
+#else
+    d_fft = new gr::fft::fft_complex_fwd(d_fftsize);
+#endif
 
     /* allocate circular buffer */
     d_cbuf.set_capacity(d_fftsize + d_audiorate);
@@ -362,7 +374,11 @@ void rx_fft_f::set_fft_size(unsigned int fftsize)
 
         /* reset FFT object (also reset FFTW plan) */
         delete d_fft;
+#if GNURADIO_VERSION < 0x030900
         d_fft = new gr::fft::fft_complex(d_fftsize, true);
+#else
+        d_fft = new gr::fft::fft_complex_fwd(d_fftsize);
+#endif
     }
 }
 

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -99,7 +99,11 @@ private:
 
     std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */
 
+#if GNURADIO_VERSION < 0x030900
     gr::fft::fft_complex    *d_fft;    /*! FFT object. */
+#else
+    gr::fft::fft_complex_fwd *d_fft;   /*! FFT object. */
+#endif
     std::vector<float>  d_window; /*! FFT window taps. */
 
     boost::circular_buffer<gr_complex> d_cbuf; /*! buffer to accumulate samples. */
@@ -164,7 +168,11 @@ private:
 
     std::mutex   d_mutex;  /*! Used to lock FFT output buffer. */
 
+#if GNURADIO_VERSION < 0x030900
     gr::fft::fft_complex    *d_fft;    /*! FFT object. */
+#else
+    gr::fft::fft_complex_fwd *d_fft;   /*! FFT object. */
+#endif
     std::vector<float>  d_window; /*! FFT window taps. */
 
     boost::circular_buffer<float> d_cbuf; /*! buffer to accumulate samples. */


### PR DESCRIPTION
Fixes #855.

GNU Radio changed its FFT API in https://github.com/gnuradio/gnuradio/pull/3903. Here I've updated Gqrx to use the new API when the GNU Radio version is 3.9 or greater.