### PR TITLE
Don't set the filter width if demod is off

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -3,6 +3,7 @@
 
        NEW: Added man page for use by distributions.
      FIXED: Crash when time span is set and waterfall height is set to 0%.
+     FIXED: Filter width is incorrectly set when demod is off.
   IMPROVED: Removed Boost.Format dependency.
 
 

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -612,7 +612,7 @@ bool MainWindow::loadConfig(const QString cfgfile, bool check_crash,
         int flo = m_settings->value("receiver/filter_low_cut", 0).toInt(&conv_ok);
         int fhi = m_settings->value("receiver/filter_high_cut", 0).toInt(&conv_ok);
 
-        if (conv_ok && flo != fhi)
+        if (conv_ok && uiDockRxOpt->currentDemod() != DockRxOpt::MODE_OFF && flo != fhi)
         {
             on_plotter_newFilterFreq(flo, fhi);
         }


### PR DESCRIPTION
Fixes #854.

If "Mode" is set to "Demod Off", then we shouldn't set the filter width during startup.