### PR TITLE
Set correct buffer size for audio FFT

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,4 +1,9 @@
 
+    2.13.5: In progress...
+
+     FIXED: Set correct buffer size for audio FFT.
+
+
     2.13.4: Released November 6, 2020
 
        NEW: Added man page for use by distributions.

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -120,7 +120,7 @@ receiver::receiver(const std::string input_device,
     dc_corr = make_dc_corr_cc(d_decim_rate, 1.0);
     iq_fft = make_rx_fft_c(8192u, d_decim_rate, gr::filter::firdes::WIN_HANN);
 
-    audio_fft = make_rx_fft_f(8192u, gr::filter::firdes::WIN_HANN);
+    audio_fft = make_rx_fft_f(8192u, d_audio_rate, gr::filter::firdes::WIN_HANN);
     audio_gain0 = gr::blocks::multiply_const_ff::make(0);
     audio_gain1 = gr::blocks::multiply_const_ff::make(0);
     set_af_gain(DEFAULT_AUDIO_GAIN);


### PR DESCRIPTION
In #728 I added an extra argument to `make_rx_fft_f`. Due to merge conflicts, the change was manually merged in c41d9890b674d5bce468fca2c3631c9bad38c99e, but the extra argument was lost in receiver.cpp. As a result, `d_audio_rate` is set to 1 (= `WIN_HANN`), which makes the circular FFT buffer small and the audio FFT & waterfall choppy. Here I've added back the missing argument, and the audio waterfall is smooth once again.