### PR TITLE
Include "Default" entry in audio output device list

### DIFF
--- a/src/qtgui/ioconfig.cpp
+++ b/src/qtgui/ioconfig.cpp
@@ -630,6 +630,7 @@ void CIoConfig::updateOutDev()
     QString outdev = m_settings->value("output/device", "").toString();
 
     ui->outDevCombo->clear();
+    ui->outDevCombo->addItem("Default");
 
     // get list of audio output devices
 #ifdef WITH_PULSEAUDIO


### PR DESCRIPTION
Fixes #862.

The change in #774 inadvertently removed the "Default" entry from the audio output device list, which shifted all the other devices up by one and broke device selection. After clearing `outDevCombo`, we need to add back the default entry that is present in ioconfig.ui.

@ulrichloose @kolbma @nmaster2042