### PR TITLE
Fix crash when closing AFSK1200 decoder

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -7,6 +7,7 @@
        NEW: Added synchronous AM demodulator.
        NEW: Added band plan to bottom of FFT.
      FIXED: PortAudio detection on MacOS.
+     FIXED: Crash when closing AFSK1200 decoder.
 
 
     2.13.5: Released November 7, 2020

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2093,6 +2093,7 @@ void MainWindow::on_actionAFSK1200_triggered()
         {
             dec_afsk1200 = new Afsk1200Win(this);
             connect(dec_afsk1200, SIGNAL(windowClosed()), this, SLOT(afsk1200win_closed()));
+            dec_afsk1200->setAttribute(Qt::WA_DeleteOnClose);
             dec_afsk1200->show();
 
             dec_timer->start(100);
@@ -2119,8 +2120,6 @@ void MainWindow::afsk1200win_closed()
     dec_timer->stop();
     rx->stop_sniffer();
 
-    /* delete decoder object */
-    delete dec_afsk1200;
     dec_afsk1200 = 0;
 }
 


### PR DESCRIPTION
Gqrx crashes when the AFSK1200 decoder window is closed because it sends a `windowClosed` signal to the main window, which then deletes the decoder window:

https://github.com/csete/gqrx/blob/b142972d634d81daf70def5f6e86c753a5412d17/src/applications/gqrx/mainwindow.cpp#L2109-L2125

But the decoder window still needs to perform additional cleanup after this point, and a use-after-free bug occurs.

To avoid this problem, I've set the `Qt::WA_DeleteOnClose` on the decoder window to ensure that it is deleted after it closes.