### PR TITLE
Make axes take precedence over demod box in plotter

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -8,6 +8,7 @@
        NEW: Added band plan to bottom of FFT.
      FIXED: PortAudio detection on MacOS.
      FIXED: Crash when closing AFSK1200 decoder.
+  IMPROVED: Make axes take precedence over demod box in plotter.
 
 
     2.13.5: Released November 7, 2020

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -241,6 +241,22 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                 setCursor(QCursor(Qt::PointingHandCursor));
                 m_CursorCaptured = BOOKMARK;
             }
+            else if (isPointCloseTo(pt.x(), m_YAxisWidth/2, m_YAxisWidth/2))
+            {
+                if (YAXIS != m_CursorCaptured)
+                    setCursor(QCursor(Qt::OpenHandCursor));
+                m_CursorCaptured = YAXIS;
+                if (m_TooltipsEnabled)
+                    QToolTip::hideText();
+            }
+            else if (isPointCloseTo(pt.y(), m_XAxisYCenter, m_CursorCaptureDelta+20))
+            {
+                if (XAXIS != m_CursorCaptured)
+                    setCursor(QCursor(Qt::OpenHandCursor));
+                m_CursorCaptured = XAXIS;
+                if (m_TooltipsEnabled)
+                    QToolTip::hideText();
+            }
             else if (isPointCloseTo(pt.x(), m_DemodFreqX, m_CursorCaptureDelta))
             {
                 // in move demod box center frequency region
@@ -276,22 +292,6 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
                                        QString("Low cut: %1 Hz")
                                                .arg(m_DemodLowCutFreq),
                                        this);
-            }
-            else if (isPointCloseTo(pt.x(), m_YAxisWidth/2, m_YAxisWidth/2))
-            {
-                if (YAXIS != m_CursorCaptured)
-                    setCursor(QCursor(Qt::OpenHandCursor));
-                m_CursorCaptured = YAXIS;
-                if (m_TooltipsEnabled)
-                    QToolTip::hideText();
-            }
-            else if (isPointCloseTo(pt.y(), m_XAxisYCenter, m_CursorCaptureDelta+5))
-            {
-                if (XAXIS != m_CursorCaptured)
-                    setCursor(QCursor(Qt::OpenHandCursor));
-                m_CursorCaptured = XAXIS;
-                if (m_TooltipsEnabled)
-                    QToolTip::hideText();
             }
             else
             {	//if not near any grab boundaries


### PR DESCRIPTION
One way to adjust the frequency zoom is to hover over the frequency axis and turn the mouse wheel. In #849 @ulrichloose pointed out that this can be difficult, particularly in the vicinity of the demod frequency where the mouse will grab the demod box instead of the axis. I've struggred with this problem as well. To avoid the problem, I've implemented @ulrichloose's suggestion of adjusting the mouse precedence so that the "open hand" cursor always appears when the mouse is hovering over the axes.