### PR TITLE
Add "F" shortcut to select the frequency controller

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -7,6 +7,7 @@
        NEW: Added synchronous AM demodulator.
        NEW: Added band plan to bottom of FFT.
        NEW: Added support for DX cluster.
+       NEW: Added "F" shortcut to select the frequency controller.
      FIXED: PortAudio detection on MacOS.
      FIXED: Crash when closing AFSK1200 decoder.
   IMPROVED: Make axes take precedence over demod box in plotter.

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -38,6 +38,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QResource>
+#include <QShortcut>
 #include <QString>
 #include <QTextBrowser>
 #include <QTextCursor>

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -149,6 +149,10 @@ MainWindow::MainWindow(const QString cfgfile, bool edit_conf, QWidget *parent) :
     uiDockBookmarks->toggleViewAction()->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_B));
     ui->mainToolBar->toggleViewAction()->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_T));
 
+    /* frequency setting shortcut */
+    QShortcut *freq_shortcut = new QShortcut(QKeySequence(Qt::Key_F), this);
+    QObject::connect(freq_shortcut, &QShortcut::activated, this, &MainWindow::frequencyFocusShortcut);
+
     setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
     setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
     setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
@@ -2431,4 +2435,9 @@ void MainWindow::on_actionAddBookmark_triggered()
 void MainWindow::updateClusterSpots()
 {
     ui->plotter->updateOverlay();
+}
+
+void MainWindow::frequencyFocusShortcut()
+{
+    ui->freqCtrl->setFrequencyFocus();
 }

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -32,7 +32,6 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSvgWidget>
-#include <QShortcut>
 
 #include "qtgui/dockrxopt.h"
 #include "qtgui/dockaudio.h"

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -32,6 +32,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include <QSvgWidget>
+#include <QShortcut>
 
 #include "qtgui/dockrxopt.h"
 #include "qtgui/dockaudio.h"
@@ -130,6 +131,8 @@ private:
     void updateGainStages(bool read_from_device);
     void showSimpleTextFile(const QString &resource_path,
                             const QString &window_title);
+    /* key shortcut */
+    void frequencyFocusShortcut();
 
 private slots:
     /* RecentConfig */

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -486,7 +486,6 @@ void CFreqCtrl::keyPressEvent(QKeyEvent *event)
     // call base class if dont over ride key
     bool      fSkipMsg = false;
     qint64    tmp;
-    uint8_t position = 0;
 
     // qDebug() <<event->key();
 

--- a/src/qtgui/freqctrl.cpp
+++ b/src/qtgui/freqctrl.cpp
@@ -486,6 +486,7 @@ void CFreqCtrl::keyPressEvent(QKeyEvent *event)
     // call base class if dont over ride key
     bool      fSkipMsg = false;
     qint64    tmp;
+    uint8_t position = 0;
 
     // qDebug() <<event->key();
 
@@ -850,4 +851,17 @@ void CFreqCtrl::cursorEnd()
         cursor().setPos(mapToGlobal(m_DigitInfo[m_FirstEditableDigit].dQRect.
                                     center()));
     }
+}
+
+void CFreqCtrl::setFrequencyFocus()
+{
+    uint8_t position = floor(log10(m_freq));
+    position = (uint8_t)fmax(position, 4);      // restrict min to 100s of kHz
+
+    QMouseEvent *mouseEvent = new QMouseEvent(QEvent::MouseMove,
+                                              m_DigitInfo[position].dQRect.center(),
+                                              Qt::NoButton,
+                                              Qt::NoButton,
+                                              Qt::NoModifier);
+    mouseMoveEvent(mouseEvent);
 }

--- a/src/qtgui/freqctrl.h
+++ b/src/qtgui/freqctrl.h
@@ -61,6 +61,7 @@ signals:
 
 public slots:
     void    setFrequency(qint64 freq);
+    void    setFrequencyFocus();
 
 protected:
     void    paintEvent(QPaintEvent *);


### PR DESCRIPTION
This replaces @andreiva's #678 with @ra1nb0w's version of the same feature.

If you get a change, please let me know if this works correctly. It looks good on Ubuntu 20.04.