### PR TITLE
Remove the "jerky dongle" workaround

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -1786,25 +1786,6 @@ void MainWindow::setPeakDetection(bool enabled)
 }
 
 /**
- * @brief Force receiver reconfiguration.
- *
- * Aka. jerky dongle workaround.
- *
- * This function forces a receiver reconfiguration by sending a fake
- * selectDemod() signal using the current demodulator selection.
- *
- * This function provides a workaround for the "jerky streaming" that has
- * been experienced using some RTL-SDR dongles when DSP processing is
- * started. The jerkyness disappears when the receiver is reconfigured
- * by selecting a new demodulator.
- */
-/*void MainWindow::forceRxReconf()
-{
-    qDebug() << "Force RX reconf (jerky dongle workarond)...";
-    selectDemod(uiDockRxOpt->currentDemod());
-}*/
-
-/**
  * @brief Start/Stop DSP processing.
  * @param checked Flag indicating whether DSP processing should be ON or OFF.
  *
@@ -1840,9 +1821,6 @@ void MainWindow::on_actionDSP_triggered(bool checked)
         /* update menu text and button tooltip */
         ui->actionDSP->setToolTip(tr("Stop DSP processing"));
         ui->actionDSP->setText(tr("Stop DSP"));
-
-        // reconfigure RX after 1s to counteract possible jerky streaming from rtl dongles
-        //QTimer::singleShot(1000, this, SLOT(forceRxReconf()));
     }
     else
     {

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -22,11 +22,6 @@
  */
 #include <cmath>
 #include <iostream>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
-
-#include <iostream>
 
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
@@ -856,11 +851,8 @@ receiver::status receiver::set_demod(rx_demod demod)
 {
     status ret = STATUS_OK;
 
-    // Allow reconf using same demod to provide a workaround
-    // for the "jerky streaming" we may experience with rtl
-    // dongles (the jerkyness disappears when we run this function)
-    //if (demod == d_demod)
-    //    return ret;
+    if (demod == d_demod)
+        return ret;
 
     // tb->lock() seems to hang occasioanlly
     if (d_running)


### PR DESCRIPTION
This removes a workaround that was added in b8182085c01787174c6b93f683211c13be3523c7. It was commented out in 53b3dcb20bb9653741e7298f3c79ceb28f67e140, so it shouldn't be needed anymore.