### PR TITLE
Fix hardware retuning when dragging frequency axis with center button

### DIFF
--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,6 +1,7 @@
 
     2.14.1: In progress...
 
+     FIXED: Hardware retuning when dragging frequency axis with center button.
   IMPROVED: More accurate rendering of FFT fill.
   IMPROVED: Better rendering of amplitude axis.
 

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2013,12 +2013,6 @@ void MainWindow::on_plotter_newFilterFreq(int low, int high)
         uiDockRxOpt->setFilterParam(low, high);
 }
 
-void MainWindow::on_plotter_newCenterFreq(qint64 f)
-{
-    rx->set_rf_freq(f);
-    ui->freqCtrl->setFrequency(f);
-}
-
 /** Full screen button or menu item toggled. */
 void MainWindow::on_actionFullScreen_triggered(bool checked)
 {

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -201,7 +201,6 @@ private slots:
     /* FFT plot */
     void on_plotter_newDemodFreq(qint64 freq, qint64 delta);   /*! New demod freq (aka. filter offset). */
     void on_plotter_newFilterFreq(int low, int high);    /*! New filter width */
-    void on_plotter_newCenterFreq(qint64 f);
 
     /* RDS */
     void setRdsDecoder(bool checked);

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -353,7 +353,7 @@ void CPlotter::mouseMoveEvent(QMouseEvent* event)
             {
                 m_CenterFreq += delta_hz;
                 m_DemodCenterFreq += delta_hz;
-                emit newCenterFreq(m_CenterFreq);
+                emit newDemodFreq(m_DemodCenterFreq, m_DemodCenterFreq - m_CenterFreq);
             }
             else
             {
@@ -656,7 +656,6 @@ void CPlotter::mousePressEvent(QMouseEvent * event)
                 // set center freq
                 m_CenterFreq = roundFreq(freqFromX(pt.x()), m_ClickResolution);
                 m_DemodCenterFreq = m_CenterFreq;
-                emit newCenterFreq(m_CenterFreq);
                 emit newDemodFreq(m_DemodCenterFreq, m_DemodCenterFreq - m_CenterFreq);
                 drawOverlay();
             }

--- a/src/qtgui/plotter.h
+++ b/src/qtgui/plotter.h
@@ -124,7 +124,6 @@ public:
     bool    saveWaterfall(const QString & filename) const;
 
 signals:
-    void newCenterFreq(qint64 f);
     void newDemodFreq(qint64 freq, qint64 delta); /* delta is the offset from the center */
     void newLowCutFreq(int f);
     void newHighCutFreq(int f);


### PR DESCRIPTION
While investigating #878, I noticed that dragging the frequency axis with the center mouse button is meant to retune the hardware frequency. But this only works correctly if the channel filter offset is zero, if it is above or below zero then the hardware frequency jumps wildly.

This function is one of only two that emits the `newCenterFreq` signal. The `newDemodFreq` signal is used elsewhere, and does everything that `newCenterFreq` does. Dragging the frequency axis with the center mouse button works correctly after switching to `newDemodFreq`.

The other function that uses `newCenterFreq` is clicking on the FFT with the center mouse button, which makes the selected frequency the new center frequency and sets the channel filter offset to zero. The `newDemodFreq` signal accomplishes that on its own, so I removed the redundant `newCenterFreq` signal.

Since nothing needs the `newCenterFreq` signal anymore, I removed it.