### PR TITLE
Use QDebug for all logging, and allow logging to be enabled at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,6 @@ endif()
 # Workaround for naming collision with log4cpp for Debug builds
 add_definitions(-DLOG4CPP_FIX_ERROR_COLLISION=1)
 
-# Disable debug outputs in release builds
-if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "RelWithDebInfo")
-    add_definitions(-DQT_NO_DEBUG_OUTPUT)
-endif()
-
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # using regular Clang or AppleClang
     set(CMAKE_COMPILER_IS_CLANGXX 1)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,24 @@ optionally, on the Projects page, under Build Steps/Make/Additional arguments,
 Use Qt Creator as before
 </pre>
 
+
+Debugging
+---------
+
+Debug logging can be enabled by setting the `QT_LOGGING_RULES` environment
+variable:
+
+```
+QT_LOGGING_RULES="*.debug=true;plotter.debug=false;qt.*.debug=false" gqrx
+```
+
+To turn on plotter debugging as well, use the following command:
+
+```
+QT_LOGGING_RULES="*.debug=true;qt.*.debug=false" gqrx
+```
+
+
 Credits and License
 -------------------
 

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -6,6 +6,7 @@
      FIXED: Tooltip for Rec button in I/Q recording dialog.
   IMPROVED: More accurate rendering of FFT fill.
   IMPROVED: Better rendering of amplitude axis.
+  IMPROVED: Allow debug logging to be enabled at runtime.
 
 
       2.14: Released November 19, 2020

--- a/src/applications/gqrx/main.cpp
+++ b/src/applications/gqrx/main.cpp
@@ -59,6 +59,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setOrganizationDomain(GQRX_ORG_DOMAIN);
     QCoreApplication::setApplicationName(GQRX_APP_NAME);
     QCoreApplication::setApplicationVersion(VERSION);
+    QLoggingCategory::setFilterRules("*.debug=false");
 
     // setup controlport via environment variables
     // see http://lists.gnu.org/archive/html/discuss-gnuradio/2013-05/msg00270.html

--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -22,6 +22,7 @@
  */
 #include <cmath>
 #include <iostream>
+#include <QDebug>
 
 #include <gnuradio/prefs.h>
 #include <gnuradio/top_block.h>
@@ -139,12 +140,9 @@ receiver::receiver(const std::string input_device,
 
     set_demod(RX_DEMOD_NFM);
 
-#ifndef QT_NO_DEBUG_OUTPUT
     gr::prefs pref;
-    std::cout << "Using audio backend: "
-              << pref.get_string("audio", "audio_module", "N/A")
-              << std::endl;
-#endif
+    qDebug() << "Using audio backend:"
+             << pref.get_string("audio", "audio_module", "N/A").c_str();
 }
 
 receiver::~receiver()
@@ -180,11 +178,9 @@ void receiver::stop()
  */
 void receiver::set_input_device(const std::string device)
 {
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cout << "Set input device:" << std::endl
-              << "  old: " << input_devstr << std::endl
-              << "  new: " << device << std::endl;
-#endif
+    qDebug() << "Set input device:";
+    qDebug() << "  old:" << input_devstr.c_str();
+    qDebug() << "  new:" << device.c_str();
 
     std::string error = "";
 
@@ -251,11 +247,9 @@ void receiver::set_input_device(const std::string device)
  */
 void receiver::set_output_device(const std::string device)
 {
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cout << "Set output device:" << std::endl
-              << "   old: " << output_devstr << std::endl
-              << "   new: " << device << std::endl;
-#endif
+    qDebug() << "Set output device:";
+    qDebug() << "   old:" << output_devstr.c_str();
+    qDebug() << "   new:" << device.c_str();
 
     output_devstr = device;
 

--- a/src/dsp/correct_iq_cc.cpp
+++ b/src/dsp/correct_iq_cc.cpp
@@ -23,6 +23,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/gr_complex.h>
 #include <iostream>
+#include <QDebug>
 #include "dsp/correct_iq_cc.h"
 
 
@@ -45,9 +46,7 @@ dc_corr_cc::dc_corr_cc(double sample_rate, double tau)
     d_tau = tau;
     d_alpha = 1.0 / (1.0 + d_tau * sample_rate);
 
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cout << "IQ DCR alpha: " << d_alpha << std::endl;
-#endif
+    qDebug() << "IQ DCR alpha:" << d_alpha;
 
     d_iir = gr::filter::single_pole_iir_filter_cc::make(d_alpha, 1);
     d_sub = gr::blocks::sub_cc::make(1);
@@ -71,10 +70,8 @@ void dc_corr_cc::set_sample_rate(double sample_rate)
 
     d_iir->set_taps(d_alpha);
 
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cout << "IQ DCR samp_rate: " << sample_rate << std::endl;
-    std::cout << "IQ DCR alpha: " << d_alpha << std::endl;
-#endif
+    qDebug() << "IQ DCR samp_rate:" << sample_rate;
+    qDebug() << "IQ DCR alpha:" << d_alpha;
 }
 
 /*! \brief Set new time constant. */
@@ -85,9 +82,7 @@ void dc_corr_cc::set_tau(double tau)
 
     d_iir->set_taps(d_alpha);
 
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cout << "IQ DCR alpha: " << d_alpha << std::endl;
-#endif
+    qDebug() << "IQ DCR alpha:" << d_alpha;
 }
 
 
@@ -131,9 +126,7 @@ void iq_swap_cc::set_enabled(bool enabled)
     if (enabled == d_enabled)
         return;
 
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cout << "IQ swap: " << enabled << std::endl;
-#endif
+    qDebug() << "IQ swap:" << enabled;
 
     d_enabled = enabled;
 

--- a/src/dsp/rx_demod_fm.cpp
+++ b/src/dsp/rx_demod_fm.cpp
@@ -24,6 +24,7 @@
 #include <gnuradio/io_signature.h>
 #include <iostream>
 #include <math.h>
+#include <QDebug>
 
 #include "dsp/rx_demod_fm.h"
 
@@ -51,9 +52,7 @@ rx_demod_fm::rx_demod_fm(float quad_rate, float max_dev, double tau)
     /* demodulator gain */
     gain = d_quad_rate / (2.0 * M_PI * d_max_dev);
 
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cerr << "FM demod gain: " << gain << std::endl;
-#endif
+    qDebug() << "FM demod gain:" << gain;
 
     /* demodulator */
     d_quad = gr::analog::quadrature_demod_cf::make(gain);

--- a/src/dsp/rx_filter.cpp
+++ b/src/dsp/rx_filter.cpp
@@ -24,6 +24,7 @@
 #include <gnuradio/io_signature.h>
 #include <gnuradio/filter/firdes.h>
 #include <iostream>
+#include <QDebug>
 #include "dsp/rx_filter.h"
 
 static const int MIN_IN = 1;  /* Minimum number of input streams. */
@@ -89,11 +90,9 @@ void rx_filter::set_param(double low, double high, double trans_width)
                                                    d_high + d_cw_offset,
                                                    d_trans_width);
 
-#ifndef QT_NO_DEBUG_OUTPUT
-    std::cout << "Generating taps for new filter   LO:" << d_low
-              << "   HI:" << d_high << " TW:" << d_trans_width
-              << "   Taps: " << d_taps.size() << std::endl;
-#endif
+    qDebug() << "Generating taps for new filter   LO:" << d_low
+             << "  HI:" << d_high << "  TW:" << d_trans_width
+             << "  Taps:" << d_taps.size();
 
     d_bpf->set_taps(d_taps);
 }
@@ -177,4 +176,3 @@ void rx_xlating_filter::set_param(double center, double low, double high, double
     set_offset(center);
     set_param(low, high, trans_width);
 }
-

--- a/src/qtgui/plotter.cpp
+++ b/src/qtgui/plotter.cpp
@@ -41,8 +41,7 @@
 #include "bookmarks.h"
 #include "dxc_spots.h"
 
-// Comment out to enable plotter debug messages
-//#define PLOTTER_DEBUG
+Q_LOGGING_CATEGORY(plotter, "plotter")
 
 #define CUR_CUT_DELTA 5		//cursor capture delta in pixels
 
@@ -751,7 +750,7 @@ void CPlotter::zoomStepX(float step, int x)
 
     float factor = (float)m_SampleFreq / (float)m_Span;
     emit newZoomLevel(factor);
-    qDebug() << QString("Spectrum zoom: %1x").arg(factor, 0, 'f', 1);
+    qCDebug(plotter) << QString("Spectrum zoom: %1x").arg(factor, 0, 'f', 1);
 
     m_PeakHoldValid = false;
 }
@@ -1427,11 +1426,9 @@ void CPlotter::drawOverlay()
     pixperdiv = (float) h * (float) dbstepsize / (m_PandMaxdB - m_PandMindB);
     adjoffset = (float) h * (mindbadj - m_PandMindB) / (m_PandMaxdB - m_PandMindB);
 
-#ifdef PLOTTER_DEBUG
-    qDebug() << "minDb =" << m_PandMindB << "maxDb =" << m_PandMaxdB
-             << "mindbadj =" << mindbadj << "dbstepsize =" << dbstepsize
-             << "pixperdiv =" << pixperdiv << "adjoffset =" << adjoffset;
-#endif
+    qCDebug(plotter) << "minDb =" << m_PandMindB << "maxDb =" << m_PandMaxdB
+                     << "mindbadj =" << mindbadj << "dbstepsize =" << dbstepsize
+                     << "pixperdiv =" << pixperdiv << "adjoffset =" << adjoffset;
 
     painter.setPen(QPen(QColor(PLOTTER_GRID_COLOR), 1, Qt::DotLine));
     for (int i = 0; i <= m_VerDivs; i++)
@@ -1707,11 +1704,9 @@ void CPlotter::toggleBandPlan(bool state)
 
 void CPlotter::calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adjlow, qint64 &step, int& divs)
 {
-#ifdef PLOTTER_DEBUG
-    qDebug() << "low: " << low;
-    qDebug() << "high: " << high;
-    qDebug() << "divswanted: " << divswanted;
-#endif
+    qCDebug(plotter) << "low:" << low;
+    qCDebug(plotter) << "high:" << high;
+    qCDebug(plotter) << "divswanted:" << divswanted;
 
     if (divswanted == 0)
         return;
@@ -1739,11 +1734,9 @@ void CPlotter::calcDivSize (qint64 low, qint64 high, int divswanted, qint64 &adj
     if (adjlow < low)
         adjlow += step;
 
-#ifdef PLOTTER_DEBUG
-    qDebug() << "adjlow: "  << adjlow;
-    qDebug() << "step: " << step;
-    qDebug() << "divs: " << divs;
-#endif
+    qCDebug(plotter) << "adjlow:" << adjlow;
+    qCDebug(plotter) << "step:" << step;
+    qCDebug(plotter) << "divs:" << divs;
 }
 
 // contributed by Chris Kuethe @ckuethe

--- a/src/receivers/nbrx.cpp
+++ b/src/receivers/nbrx.cpp
@@ -22,6 +22,7 @@
  */
 #include <cmath>
 #include <iostream>
+#include <QDebug>
 #include "receivers/nbrx.h"
 
 // NB: Remember to adjust filter ranges in MainWindow
@@ -103,9 +104,7 @@ void nbrx::set_quad_rate(float quad_rate)
 {
     if (std::abs(d_quad_rate-quad_rate) > 0.5)
     {
-#ifndef QT_NO_DEBUG_OUTPUT
-        std::cout << "Changing NB_RX quad rate: "  << d_quad_rate << " -> " << quad_rate << std::endl;
-#endif
+        qDebug() << "Changing NB_RX quad rate:"  << d_quad_rate << "->" << quad_rate;
         d_quad_rate = quad_rate;
         lock();
         iq_resamp->set_rate(PREF_QUAD_RATE/d_quad_rate);

--- a/src/receivers/wfmrx.cpp
+++ b/src/receivers/wfmrx.cpp
@@ -23,6 +23,7 @@
  */
 #include <cmath>
 #include <iostream>
+#include <QDebug>
 #include "receivers/wfmrx.h"
 
 #define PREF_QUAD_RATE   240e3 // Nominal channel spacing is 200 kHz
@@ -92,9 +93,7 @@ void wfmrx::set_quad_rate(float quad_rate)
 {
     if (std::abs(d_quad_rate-quad_rate) > 0.5)
     {
-#ifndef QT_NO_DEBUG_OUTPUT
-        std::cerr << "Changing WFM RX quad rate: "  << d_quad_rate << " -> " << quad_rate << std::endl;
-#endif
+        qDebug() << "Changing WFM RX quad rate:"  << d_quad_rate << "->" << quad_rate;
         d_quad_rate = quad_rate;
         lock();
         iq_resamp->set_rate(PREF_QUAD_RATE/d_quad_rate);


### PR DESCRIPTION
Gqrx has debug logging, but it can only be enabled at compile time. It would be convenient to allow it to be turned on at runtime instead. Qt 5.2 added categorized logging, which makes this easy: https://doc.qt.io/qt-5/qloggingcategory.html

The plotter previously had its own logging which could be enabled by defining `PLOTTER_DEBUG`, so I made that into its own logging category (`plotter`). In some other files, logging was performed with `std::cout` and `std::cerr` inside `#ifndef QT_NO_DEBUG_OUTPUT` blocks, presumably to avoid depending on Qt. I've switched to `qDebug()` in those files.

Finally, I removed `QT_NO_DEBUG_OUTPUT` from the cmake build and changed `main.cpp` to disable debug logging by default. Gqrx can be run with debug logging enabled like so:

`QT_LOGGING_RULES="*.debug=true;plotter.debug=false;qt.*.debug=false" gqrx`

Plotter debugging can be included like so:

`QT_LOGGING_RULES="*.debug=true;qt.*.debug=false" gqrx`