### PR TITLE
Add button to lock audio fft and wf ranges

### DIFF
--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -24,8 +24,6 @@
 #include <QPalette>
 #include <QDebug>
 
-#include <iostream>
-
 #include "audio_options.h"
 #include "ui_audio_options.h"
 

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -128,6 +128,8 @@ void CAudioOptions::on_pandRangeSlider_valuesChanged(int min, int max)
 {
     if (ui->audioLockButton->isChecked())
         ui->wfRangeSlider->setValues(min, max);
+
+    m_pand_last_modified = true;
     emit newPandapterRange(min, max);
 }
 
@@ -147,7 +149,28 @@ void CAudioOptions::on_wfRangeSlider_valuesChanged(int min, int max)
 {
     if (ui->audioLockButton->isChecked())
         ui->pandRangeSlider->setValues(min, max);
+
+    m_pand_last_modified = false;
     emit newWaterfallRange(min, max);
+}
+
+/** Lock button toggled */
+void CAudioOptions::on_audioLockButton_toggled(bool checked)
+{
+    if (checked) {
+        if (m_pand_last_modified)
+        {
+            int min = ui->pandRangeSlider->minimumValue();
+            int max = ui->pandRangeSlider->maximumValue();
+            ui->wfRangeSlider->setPositions(min, max);
+        }
+        else
+        {
+            int min = ui->wfRangeSlider->minimumValue();
+            int max = ui->wfRangeSlider->maximumValue();
+            ui->pandRangeSlider->setPositions(min, max);
+        }
+    }
 }
 
 

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -24,6 +24,8 @@
 #include <QPalette>
 #include <QDebug>
 
+#include <iostream>
+
 #include "audio_options.h"
 #include "ui_audio_options.h"
 
@@ -126,6 +128,8 @@ void CAudioOptions::getPandapterRange(int * min, int * max) const
 
 void CAudioOptions::on_pandRangeSlider_valuesChanged(int min, int max)
 {
+    if (ui->audioLockButton->isChecked())
+        ui->wfRangeSlider->setValues(min, max);
     emit newPandapterRange(min, max);
 }
 
@@ -143,6 +147,8 @@ void CAudioOptions::getWaterfallRange(int * min, int * max) const
 
 void CAudioOptions::on_wfRangeSlider_valuesChanged(int min, int max)
 {
+    if (ui->audioLockButton->isChecked())
+        ui->pandRangeSlider->setValues(min, max);
     emit newWaterfallRange(min, max);
 }
 

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -147,7 +147,12 @@ void CAudioOptions::getWaterfallRange(int * min, int * max) const
 
 void CAudioOptions::setPandapterSliderValues(float min, float max)
 {
+    ui->pandRangeSlider->blockSignals(true);
     ui->pandRangeSlider->setValues((int)min, (int)max);
+    if (ui->audioLockButton->isChecked())
+        ui->wfRangeSlider->setValues((int) min, (int) max);
+    m_pand_last_modified = true;
+    ui->pandRangeSlider->blockSignals(false);
 }
 
 void CAudioOptions::on_wfRangeSlider_valuesChanged(int min, int max)

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -145,6 +145,11 @@ void CAudioOptions::getWaterfallRange(int * min, int * max) const
     *max = ui->wfRangeSlider->maximumValue();
 }
 
+void CAudioOptions::setPandapterSliderValues(float min, float max)
+{
+    ui->pandRangeSlider->setValues((int)min, (int)max);
+}
+
 void CAudioOptions::on_wfRangeSlider_valuesChanged(int min, int max)
 {
     if (ui->audioLockButton->isChecked())

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -154,6 +154,16 @@ void CAudioOptions::on_wfRangeSlider_valuesChanged(int min, int max)
     emit newWaterfallRange(min, max);
 }
 
+void CAudioOptions::setLockButtonState(bool checked)
+{
+    ui->audioLockButton->setChecked(checked);
+}
+
+bool CAudioOptions::getLockButtonState(void) const
+{
+    return ui->audioLockButton->isChecked();
+}
+
 void CAudioOptions::setPandapterSliderValues(float min, float max)
 {
     ui->pandRangeSlider->blockSignals(true);

--- a/src/qtgui/audio_options.cpp
+++ b/src/qtgui/audio_options.cpp
@@ -145,6 +145,15 @@ void CAudioOptions::getWaterfallRange(int * min, int * max) const
     *max = ui->wfRangeSlider->maximumValue();
 }
 
+void CAudioOptions::on_wfRangeSlider_valuesChanged(int min, int max)
+{
+    if (ui->audioLockButton->isChecked())
+        ui->pandRangeSlider->setValues(min, max);
+
+    m_pand_last_modified = false;
+    emit newWaterfallRange(min, max);
+}
+
 void CAudioOptions::setPandapterSliderValues(float min, float max)
 {
     ui->pandRangeSlider->blockSignals(true);
@@ -153,15 +162,6 @@ void CAudioOptions::setPandapterSliderValues(float min, float max)
         ui->wfRangeSlider->setValues((int) min, (int) max);
     m_pand_last_modified = true;
     ui->pandRangeSlider->blockSignals(false);
-}
-
-void CAudioOptions::on_wfRangeSlider_valuesChanged(int min, int max)
-{
-    if (ui->audioLockButton->isChecked())
-        ui->pandRangeSlider->setValues(min, max);
-
-    m_pand_last_modified = false;
-    emit newWaterfallRange(min, max);
 }
 
 /** Lock button toggled */

--- a/src/qtgui/audio_options.h
+++ b/src/qtgui/audio_options.h
@@ -73,6 +73,7 @@ private slots:
     void on_fftSplitSlider_valueChanged(int value);
     void on_pandRangeSlider_valuesChanged(int min, int max);
     void on_wfRangeSlider_valuesChanged(int min, int max);
+    void on_audioLockButton_toggled(bool checked);
     void on_recDirEdit_textChanged(const QString &text);
     void on_recDirButton_clicked();
     void on_udpHost_textChanged(const QString &text);
@@ -83,6 +84,7 @@ private:
     Ui::CAudioOptions *ui;            /*!< The user interface widget. */
     QDir              *work_dir;      /*!< Used for validating chosen directory. */
     QPalette          *error_palette; /*!< Palette used to indicate an error. */
+    bool               m_pand_last_modified; /* Flag to indicate which slider was changed last */
 };
 
 #endif // AUDIO_OPTIONS_H

--- a/src/qtgui/audio_options.h
+++ b/src/qtgui/audio_options.h
@@ -81,10 +81,10 @@ private slots:
     void on_udpStereo_stateChanged(int state);
 
 private:
-    Ui::CAudioOptions *ui;            /*!< The user interface widget. */
-    QDir              *work_dir;      /*!< Used for validating chosen directory. */
-    QPalette          *error_palette; /*!< Palette used to indicate an error. */
-    bool               m_pand_last_modified; /* Flag to indicate which slider was changed last */
+    Ui::CAudioOptions *ui;                   /*!< The user interface widget. */
+    QDir              *work_dir;             /*!< Used for validating chosen directory. */
+    QPalette          *error_palette;        /*!< Palette used to indicate an error. */
+    bool               m_pand_last_modified; /*!< Flag to indicate which slider was changed last */
 };
 
 #endif // AUDIO_OPTIONS_H

--- a/src/qtgui/audio_options.h
+++ b/src/qtgui/audio_options.h
@@ -57,6 +57,9 @@ public:
     void setWaterfallRange(int min, int max);
     void getWaterfallRange(int * min, int * max) const;
 
+public slots:
+    void setPandapterSliderValues(float min, float max);
+
 signals:
     void newFftSplit(int pct_2d);
     void newPandapterRange(int min, int max);

--- a/src/qtgui/audio_options.h
+++ b/src/qtgui/audio_options.h
@@ -57,6 +57,9 @@ public:
     void setWaterfallRange(int min, int max);
     void getWaterfallRange(int * min, int * max) const;
 
+    void setLockButtonState(bool checked);
+    bool getLockButtonState(void) const;
+
 public slots:
     void setPandapterSliderValues(float min, float max);
 

--- a/src/qtgui/audio_options.ui
+++ b/src/qtgui/audio_options.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>315</width>
-    <height>169</height>
+    <height>182</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,7 +21,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tab0">
       <attribute name="title">
@@ -137,6 +137,28 @@
            </property>
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QPushButton" name="audioLockButton">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Lock panadapter and waterfall sliders together</string>
+           </property>
+           <property name="statusTip">
+            <string>Lock panadapter and waterfall sliders together</string>
+           </property>
+           <property name="text">
+            <string>Lock</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
            </property>
           </widget>
          </item>

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -64,6 +64,8 @@ DockAudio::DockAudio(QWidget *parent) :
     connect(audioOptions, SIGNAL(newUdpPort(int)), this, SLOT(setNewUdpPort(int)));
     connect(audioOptions, SIGNAL(newUdpStereo(bool)), this, SLOT(setNewUdpStereo(bool)));
 
+    connect(ui->audioSpectrum, SIGNAL(pandapterRangeChanged(float,float)), audioOptions, SLOT(setPandapterSliderValues(float,float)));
+
     ui->audioSpectrum->setFreqUnits(1000);
     ui->audioSpectrum->setSampleRate(48000);  // Full bandwidth
     ui->audioSpectrum->setSpanFreq(12000);

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -351,6 +351,11 @@ void DockAudio::saveSettings(QSettings *settings)
     else
         settings->remove("waterfall_max_db");
 
+    if (audioOptions->getLockButtonState()) 
+        settings->setValue("db_ranges_locked", true); 
+    else 
+        settings->remove("db_ranges_locked"); 
+
     if (rec_dir != QDir::homePath())
         settings->setValue("rec_dir", rec_dir);
     else
@@ -407,6 +412,8 @@ void DockAudio::readSettings(QSettings *settings)
     if (!conv_ok)
         fft_max = 0;
     audioOptions->setWaterfallRange(fft_min, fft_max);
+
+    audioOptions->setLockButtonState(settings->value("db_ranges_locked", false).toBool());
 
     // Location of audio recordings
     rec_dir = settings->value("rec_dir", QDir::homePath()).toString();

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -381,7 +381,7 @@ void DockAudio::saveSettings(QSettings *settings)
 
 void DockAudio::readSettings(QSettings *settings)
 {
-    int     ival, fft_min, fft_max;
+    int     bool_val, ival, fft_min, fft_max;
     bool    conv_ok = false;
 
     if (!settings)
@@ -413,7 +413,8 @@ void DockAudio::readSettings(QSettings *settings)
         fft_max = 0;
     audioOptions->setWaterfallRange(fft_min, fft_max);
 
-    audioOptions->setLockButtonState(settings->value("db_ranges_locked", false).toBool());
+    bool_val = settings->value("db_ranges_locked", false).toBool();
+    audioOptions->setLockButtonState(bool_val);
 
     // Location of audio recordings
     rec_dir = settings->value("rec_dir", QDir::homePath()).toString();


### PR DESCRIPTION
Implements #892. Added Lock buttin in audio options dialog to lock audio fft and waterfall ranges.