### PR TITLE
Fix Shuyuan's name in contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ The following people and organisations have contributed to gqrx:
 * Kate Adams
 * Kitware Inc.
 * Konrad Beckmann
-* Liu Shuyuan
 * luzpaz
 * Marco Savelli
 * Markus Kolb
@@ -228,6 +227,7 @@ The following people and organisations have contributed to gqrx:
 * Phil Vachon
 * Rob Frohne
 * Ron Economos, W6RZ
+* Shuyuan Liu
 * Stefano Leucci
 * Sylvain Munaut
 * Tarmo Tanilsoo


### PR DESCRIPTION
First of all, sorry because I had my surname first in my user profile while it should have been given name first.

I fixed my name in the contributors and put it in the right place on the list, by alphabetical order.