### PR TITLE
How about some more keyboard shortcuts?

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The following people and organisations have contributed to gqrx:
 * Stefano Leucci
 * Sylvain Munaut
 * Tarmo Tanilsoo
+* Tomasz Lemiech
 * Timothy Reaves
 * Valentin Ochs
 * Vesa Solonen

--- a/resources/kbd-shortcuts.txt
+++ b/resources/kbd-shortcuts.txt
@@ -2,31 +2,31 @@ Keyboard shortcuts
 
 Main window actions:
 
- ctrl+d         Start/stop DSP
- ctrl+l         Load settings from a file
- ctrl+s         Save current settings to a file
- ctrl+shift+b   Bookmark the current frequency and mode
- ctrl+i         Open I/Q recorder dialog
- ctrl+w         Save waterfall as an image
- ctrl+c         Open DX cluster dialog
+ Ctrl+D         Start/stop DSP
+ Ctrl+L         Load settings from a file
+ Ctrl+S         Save current settings to a file
+ Ctrl+Shift+B   Bookmark the current frequency and mode
+ Ctrl+I         Open I/Q recorder dialog
+ Ctrl+W         Save waterfall as an image
+ Ctrl+C         Open DX cluster dialog
  F11            Toggle full screen mode
- f              Set focus to the frequency controller
- ctrl+q         Quit the program
+ F              Set focus to the frequency controller
+ Ctrl+Q         Quit the program
 
 Receiver modes:
 
  !              Demod off
- i              Raw I/Q
- a              AM
- n              NFM
- w              WFM mono
- shift+w        WFM stereo
- s              LSB  (memo: lower SSB)
- shift+s        USB  (memo: upper SSB)
- c              CW-L (memo: lower CW)
- shift+c        CW-U (memo: upper CW)
- o              WFM oirt
- shift+a        AM sync
+ I              Raw I/Q
+ A              AM
+ N              NFM
+ W              WFM mono
+ Shift+W        WFM stereo
+ S              LSB  (memo: lower SSB)
+ Shift+S        USB  (memo: upper SSB)
+ C              CW-L (memo: lower CW)
+ Shift+C        CW-U (memo: upper CW)
+ O              WFM oirt
+ Shift+A        AM sync
 
 Squelch:
 
@@ -41,7 +41,7 @@ Filter width:
 
 Audio functions:
 
- r              Start/stop recording
- m              Toggle mute
+ R              Start/stop recording
+ M              Toggle mute
  -              Decrease gain by 1 dB
  +              Increase gain by 1 dB

--- a/resources/kbd-shortcuts.txt
+++ b/resources/kbd-shortcuts.txt
@@ -1,0 +1,47 @@
+Keyboard shortcuts
+
+Main window actions:
+
+ ctrl+d         Start/stop DSP
+ ctrl+l         Load settings from a file
+ ctrl+s         Save current settings to a file
+ ctrl+shift+b   Bookmark the current frequency and mode
+ ctrl+i         Open I/Q recorder dialog
+ ctrl+w         Save waterfall as an image
+ ctrl+c         Open DX cluster dialog
+ F11            Toggle full screen mode
+ f              Set focus to the frequency controller
+ ctrl+q         Quit the program
+
+Receiver modes:
+
+ !              Demod off
+ i              Raw I/Q
+ a              AM
+ n              NFM
+ w              WFM mono
+ shift+w        WFM stereo
+ s              LSB  (memo: lower SSB)
+ shift+s        USB  (memo: upper SSB)
+ c              CW-L (memo: lower CW)
+ shift+c        CW-U (memo: upper CW)
+ o              WFM oirt
+ shift+a        AM sync
+
+Squelch:
+
+ `              Reset squelch
+ ~              Auto squelch
+
+Filter width:
+
+ <              Narrow
+ .              Normal
+ >              Wide
+
+Audio functions:
+
+ r              Start/stop recording
+ m              Toggle mute
+ -              Decrease gain by 1 dB
+ +              Increase gain by 1 dB

--- a/resources/news.txt
+++ b/resources/news.txt
@@ -1,6 +1,7 @@
 
     2.14.4: In progress...
 
+       NEW: Many more keyboard shortcuts.
      FIXED: Audio output doesn't work on MacOS Big Sur.
 
 

--- a/resources/textfiles.qrc
+++ b/resources/textfiles.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/textfiles">
         <file>news.txt</file>
         <file>remote-control.txt</file>
+        <file>kbd-shortcuts.txt</file>
         <file>bandplan.csv</file>
     </qresource>
 </RCC>

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2230,6 +2230,15 @@ void MainWindow::on_actionRemoteProtocol_triggered()
 }
 
 /**
+ * Show kbd-shortcuts.txt in a dialog window.
+ */
+void MainWindow::on_actionKbdShortcuts_triggered()
+{
+    showSimpleTextFile(":/textfiles/kbd-shortcuts.txt",
+                       tr("Keyboard shortcuts"));
+}
+
+/**
  * Show simple text file in a window.
  */
 void MainWindow::showSimpleTextFile(const QString &resource_path,

--- a/src/applications/gqrx/mainwindow.h
+++ b/src/applications/gqrx/mainwindow.h
@@ -225,6 +225,7 @@ private slots:
     void on_actionUserGroup_triggered();
     void on_actionNews_triggered();
     void on_actionRemoteProtocol_triggered();
+    void on_actionKbdShortcuts_triggered();
     void on_actionAbout_triggered();
     void on_actionAboutQt_triggered();
     void on_actionAddBookmark_triggered();

--- a/src/applications/gqrx/mainwindow.ui
+++ b/src/applications/gqrx/mainwindow.ui
@@ -234,6 +234,7 @@
     <addaction name="actionNews"/>
     <addaction name="separator"/>
     <addaction name="actionRemoteProtocol"/>
+    <addaction name="actionKbdShortcuts"/>
     <addaction name="separator"/>
     <addaction name="actionAbout"/>
     <addaction name="actionAboutQt"/>
@@ -538,6 +539,18 @@
    </property>
    <property name="toolTip">
     <string>Remote control protocol</string>
+   </property>
+  </action>
+  <action name="actionKbdShortcuts">
+   <property name="icon">
+    <iconset resource="../../../resources/icons.qrc">
+     <normaloff>:/icons/icons/info.svg</normaloff>:/icons/icons/info.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Keyboard shortcuts</string>
+   </property>
+   <property name="toolTip">
+    <string>Show help on keyboard shortcuts</string>
    </property>
   </action>
   <action name="actionSaveWaterfall">

--- a/src/qtgui/dockaudio.cpp
+++ b/src/qtgui/dockaudio.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <QDebug>
 #include <QDateTime>
+#include <QShortcut>
 #include <QDir>
 #include "dockaudio.h"
 #include "ui_dockaudio.h"
@@ -73,6 +74,16 @@ DockAudio::DockAudio(QWidget *parent) :
     ui->audioSpectrum->setVdivDelta(40);
     ui->audioSpectrum->setHdivDelta(40);
     ui->audioSpectrum->setFreqDigits(1);
+
+    QShortcut *rec_toggle_shortcut = new QShortcut(QKeySequence(Qt::Key_R), this);
+    QShortcut *mute_toggle_shortcut = new QShortcut(QKeySequence(Qt::Key_M), this);
+    QShortcut *audio_gain_increase_shortcut1 = new QShortcut(QKeySequence(Qt::Key_Plus), this);
+    QShortcut *audio_gain_decrease_shortcut1 = new QShortcut(QKeySequence(Qt::Key_Minus), this);
+
+    QObject::connect(rec_toggle_shortcut, &QShortcut::activated, this, &DockAudio::recordToggleShortcut);
+    QObject::connect(mute_toggle_shortcut, &QShortcut::activated, this, &DockAudio::muteToggleShortcut);
+    QObject::connect(audio_gain_increase_shortcut1, &QShortcut::activated, this, &DockAudio::increaseAudioGainShortcut);
+    QObject::connect(audio_gain_decrease_shortcut1, &QShortcut::activated, this, &DockAudio::decreaseAudioGainShortcut);
 }
 
 DockAudio::~DockAudio()
@@ -468,4 +479,20 @@ void DockAudio::setNewUdpPort(int port)
 void DockAudio::setNewUdpStereo(bool enabled)
 {
     udp_stereo = enabled;
+}
+
+void DockAudio::recordToggleShortcut() {
+    ui->audioRecButton->click();
+}
+
+void DockAudio::muteToggleShortcut() {
+    ui->audioMuteButton->click();
+}
+
+void DockAudio::increaseAudioGainShortcut() {
+	ui->audioGainSlider->triggerAction(QSlider::SliderPageStepAdd);
+}
+
+void DockAudio::decreaseAudioGainShortcut() {
+	ui->audioGainSlider->triggerAction(QSlider::SliderPageStepSub);
 }

--- a/src/qtgui/dockaudio.h
+++ b/src/qtgui/dockaudio.h
@@ -126,6 +126,11 @@ private:
     bool           autoSpan;     /*! Whether to allow mode-dependent auto span. */
 
     qint64         rx_freq;      /*! RX frequency used in filenames. */
+
+    void           recordToggleShortcut();
+    void           muteToggleShortcut();
+    void           increaseAudioGainShortcut();
+    void           decreaseAudioGainShortcut();
 };
 
 #endif // DOCKAUDIO_H

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -22,6 +22,7 @@
  */
 #include <QDebug>
 #include <QVariant>
+#include <QShortcut>
 #include <iostream>
 #include "dockrxopt.h"
 #include "ui_dockrxopt.h"
@@ -110,6 +111,49 @@ DockRxOpt::DockRxOpt(qint64 filterOffsetRange, QWidget *parent) :
     // Noise blanker options
     nbOpt = new CNbOptions(this);
     connect(nbOpt, SIGNAL(thresholdChanged(int,double)), this, SLOT(nbOpt_thresholdChanged(int,double)));
+
+    /* mode setting shortcuts */
+    QShortcut *mode_off_shortcut = new QShortcut(QKeySequence(Qt::Key_Exclam), this);
+    QShortcut *mode_raw_shortcut = new QShortcut(QKeySequence(Qt::Key_I), this);
+    QShortcut *mode_am_shortcut = new QShortcut(QKeySequence(Qt::Key_A), this);
+    QShortcut *mode_nfm_shortcut = new QShortcut(QKeySequence(Qt::Key_N), this);
+    QShortcut *mode_wfm_mono_shortcut = new QShortcut(QKeySequence(Qt::Key_W), this);
+    QShortcut *mode_wfm_stereo_shortcut = new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_W), this);
+    QShortcut *mode_lsb_shortcut = new QShortcut(QKeySequence(Qt::Key_S), this);
+    QShortcut *mode_usb_shortcut = new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_S), this);
+    QShortcut *mode_cwl_shortcut = new QShortcut(QKeySequence(Qt::Key_C), this);
+    QShortcut *mode_cwu_shortcut = new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_C), this);
+    QShortcut *mode_wfm_oirt_shortcut = new QShortcut(QKeySequence(Qt::Key_O), this);
+    QShortcut *mode_am_sync_shortcut = new QShortcut(QKeySequence(Qt::SHIFT + Qt::Key_A), this);
+
+    QObject::connect(mode_off_shortcut, &QShortcut::activated, this, &DockRxOpt::modeOffShortcut);
+    QObject::connect(mode_raw_shortcut, &QShortcut::activated, this, &DockRxOpt::modeRawShortcut);
+    QObject::connect(mode_am_shortcut, &QShortcut::activated, this, &DockRxOpt::modeAMShortcut);
+    QObject::connect(mode_nfm_shortcut, &QShortcut::activated, this, &DockRxOpt::modeNFMShortcut);
+    QObject::connect(mode_wfm_mono_shortcut, &QShortcut::activated, this, &DockRxOpt::modeWFMmonoShortcut);
+    QObject::connect(mode_wfm_stereo_shortcut, &QShortcut::activated, this, &DockRxOpt::modeWFMstereoShortcut);
+    QObject::connect(mode_lsb_shortcut, &QShortcut::activated, this, &DockRxOpt::modeLSBShortcut);
+    QObject::connect(mode_usb_shortcut, &QShortcut::activated, this, &DockRxOpt::modeUSBShortcut);
+    QObject::connect(mode_cwl_shortcut, &QShortcut::activated, this, &DockRxOpt::modeCWLShortcut);
+    QObject::connect(mode_cwu_shortcut, &QShortcut::activated, this, &DockRxOpt::modeCWUShortcut);
+    QObject::connect(mode_wfm_oirt_shortcut, &QShortcut::activated, this, &DockRxOpt::modeWFMoirtShortcut);
+    QObject::connect(mode_am_sync_shortcut, &QShortcut::activated, this, &DockRxOpt::modeAMsyncShortcut);
+
+    /* squelch shortcuts */
+    QShortcut *squelch_reset_shortcut = new QShortcut(QKeySequence(Qt::Key_QuoteLeft), this);
+    QShortcut *squelch_auto_shortcut = new QShortcut(QKeySequence(Qt::Key_AsciiTilde), this);
+
+    QObject::connect(squelch_reset_shortcut, &QShortcut::activated, this, &DockRxOpt::on_resetSquelchButton_clicked);
+    QObject::connect(squelch_auto_shortcut, &QShortcut::activated, this, &DockRxOpt::on_autoSquelchButton_clicked);
+
+    /* filter width shortcuts */
+    QShortcut *filter_narrow_shortcut = new QShortcut(QKeySequence(Qt::Key_Less), this);
+    QShortcut *filter_normal_shortcut = new QShortcut(QKeySequence(Qt::Key_Period), this);
+    QShortcut *filter_wide_shortcut = new QShortcut(QKeySequence(Qt::Key_Greater), this);
+
+    QObject::connect(filter_narrow_shortcut, &QShortcut::activated, this, &DockRxOpt::filterNarrowShortcut);
+    QObject::connect(filter_normal_shortcut, &QShortcut::activated, this, &DockRxOpt::filterNormalShortcut);
+    QObject::connect(filter_wide_shortcut, &QShortcut::activated, this, &DockRxOpt::filterWideShortcut);
 }
 
 DockRxOpt::~DockRxOpt()
@@ -791,4 +835,67 @@ bool DockRxOpt::IsModulationValid(QString strModulation)
 QString DockRxOpt::GetStringForModulationIndex(int iModulationIndex)
 {
     return ModulationStrings[iModulationIndex];
+}
+
+void DockRxOpt::modeOffShortcut() {
+    on_modeSelector_activated(MODE_OFF);
+}
+
+void DockRxOpt::modeRawShortcut() {
+    on_modeSelector_activated(MODE_RAW);
+}
+
+void DockRxOpt::modeAMShortcut() {
+    on_modeSelector_activated(MODE_AM);
+}
+
+void DockRxOpt::modeNFMShortcut() {
+    on_modeSelector_activated(MODE_NFM);
+}
+
+void DockRxOpt::modeWFMmonoShortcut() {
+    on_modeSelector_activated(MODE_WFM_MONO);
+}
+
+void DockRxOpt::modeWFMstereoShortcut() {
+    on_modeSelector_activated(MODE_WFM_STEREO);
+}
+
+void DockRxOpt::modeLSBShortcut() {
+    on_modeSelector_activated(MODE_LSB);
+}
+
+void DockRxOpt::modeUSBShortcut() {
+    on_modeSelector_activated(MODE_USB);
+}
+
+void DockRxOpt::modeCWLShortcut() {
+    on_modeSelector_activated(MODE_CWL);
+}
+
+void DockRxOpt::modeCWUShortcut() {
+    on_modeSelector_activated(MODE_CWU);
+}
+
+void DockRxOpt::modeWFMoirtShortcut() {
+    on_modeSelector_activated(MODE_WFM_STEREO_OIRT);
+}
+
+void DockRxOpt::modeAMsyncShortcut() {
+    on_modeSelector_activated(MODE_AM_SYNC);
+}
+
+void DockRxOpt::filterNarrowShortcut() {
+    setCurrentFilter(FILTER_PRESET_NARROW);
+    on_filterCombo_activated(FILTER_PRESET_NARROW);
+}
+
+void DockRxOpt::filterNormalShortcut() {
+    setCurrentFilter(FILTER_PRESET_NORMAL);
+    on_filterCombo_activated(FILTER_PRESET_NORMAL);
+}
+
+void DockRxOpt::filterWideShortcut() {
+    setCurrentFilter(FILTER_PRESET_WIDE);
+    on_filterCombo_activated(FILTER_PRESET_WIDE);
 }

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -128,6 +128,22 @@ private:
     void updateDemodOptPage(int demod);
     unsigned int filterIdxFromLoHi(int lo, int hi) const;
 
+    void modeOffShortcut();
+    void modeRawShortcut();
+    void modeAMShortcut();
+    void modeNFMShortcut();
+    void modeWFMmonoShortcut();
+    void modeWFMstereoShortcut();
+    void modeLSBShortcut();
+    void modeUSBShortcut();
+    void modeCWLShortcut();
+    void modeCWUShortcut();
+    void modeWFMoirtShortcut();
+    void modeAMsyncShortcut();
+    void filterNarrowShortcut();
+    void filterNormalShortcut();
+    void filterWideShortcut();
+
 signals:
     /** Signal emitted when receiver frequency has changed */
     void rxFreqChanged(qint64 freq_hz);


### PR DESCRIPTION
This PR adds keyboard shortcuts for some receiver options and audio-related functions. I find them convenient especially on HF, where many modes and filter widths are in use.

Modes:

- `!` - Demod off
- `i` - Raw I/Q
- `a` - AM
- `n` - NFM
- `w` - WFM mono
- `shift+w` - WFM stereo
- `s` - LSB (memo: lower SSB)
- `shift+s` - USB (memo: upper SSB)
- `c` - CW-L
- `shift+c` - CW-U
- `o` - WFM oirt
- `shift+a` - AM sync

Squelch:

- `` ` `` - reset squelch
- `~` - auto squelch

Filter width:

- `<` - narrow
- `.` - normal
- `>` - wide

Audio functions:

- `r` - start/stop recording
- `m` - toggle mute
- `-` - decrease gain by 1 dB
- `+` - increase gain by 1 dB
