### PR TITLE
Window namespace change in GR 3.9

### DIFF
--- a/src/applications/gqrx/receiver.cpp
+++ b/src/applications/gqrx/receiver.cpp
@@ -113,9 +113,9 @@ receiver::receiver(const std::string input_device,
 
     iq_swap = make_iq_swap_cc(false);
     dc_corr = make_dc_corr_cc(d_decim_rate, 1.0);
-    iq_fft = make_rx_fft_c(8192u, d_decim_rate, gr::filter::firdes::WIN_HANN);
+    iq_fft = make_rx_fft_c(8192u, d_decim_rate, gr::fft::window::WIN_HANN);
 
-    audio_fft = make_rx_fft_f(8192u, d_audio_rate, gr::filter::firdes::WIN_HANN);
+    audio_fft = make_rx_fft_f(8192u, d_audio_rate, gr::fft::window::WIN_HANN);
     audio_gain0 = gr::blocks::multiply_const_ff::make(0);
     audio_gain1 = gr::blocks::multiply_const_ff::make(0);
     set_af_gain(DEFAULT_AUDIO_GAIN);

--- a/src/dsp/rx_fft.cpp
+++ b/src/dsp/rx_fft.cpp
@@ -36,7 +36,7 @@ rx_fft_c_sptr make_rx_fft_c (unsigned int fftsize, double quad_rate, int wintype
 
 /*! \brief Create receiver FFT object.
  *  \param fftsize The FFT size.
- *  \param wintype The window type (see gr::filter::firdes::win_type).
+ *  \param wintype The window type (see gr::fft::window::win_type).
  *
  */
 rx_fft_c::rx_fft_c(unsigned int fftsize, double quad_rate, int wintype)
@@ -212,13 +212,13 @@ void rx_fft_c::set_window_type(int wintype)
 
     d_wintype = wintype;
 
-    if ((d_wintype < gr::filter::firdes::WIN_HAMMING) || (d_wintype > gr::filter::firdes::WIN_FLATTOP))
+    if ((d_wintype < gr::fft::window::WIN_HAMMING) || (d_wintype > gr::fft::window::WIN_FLATTOP))
     {
-        d_wintype = gr::filter::firdes::WIN_HAMMING;
+        d_wintype = gr::fft::window::WIN_HAMMING;
     }
 
     d_window.clear();
-    d_window = gr::filter::firdes::window((gr::filter::firdes::win_type)d_wintype, d_fftsize, 6.76);
+    d_window = gr::fft::window::build((gr::fft::window::win_type)d_wintype, d_fftsize, 6.76);
 }
 
 /*! \brief Get currently used window type. */
@@ -237,7 +237,7 @@ rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize, double audio_rate, int wintype
 
 /*! \brief Create receiver FFT object.
  *  \param fftsize The FFT size.
- *  \param wintype The window type (see gr::filter::firdes::win_type).
+ *  \param wintype The window type (see gr::fft::window::win_type).
  *
  */
 rx_fft_f::rx_fft_f(unsigned int fftsize, double audio_rate, int wintype)
@@ -399,13 +399,13 @@ void rx_fft_f::set_window_type(int wintype)
 
     d_wintype = wintype;
 
-    if ((d_wintype < gr::filter::firdes::WIN_HAMMING) || (d_wintype > gr::filter::firdes::WIN_FLATTOP))
+    if ((d_wintype < gr::fft::window::WIN_HAMMING) || (d_wintype > gr::fft::window::WIN_FLATTOP))
     {
-        d_wintype = gr::filter::firdes::WIN_HAMMING;
+        d_wintype = gr::fft::window::WIN_HAMMING;
     }
 
     d_window.clear();
-    d_window = gr::filter::firdes::window((gr::filter::firdes::win_type)d_wintype, d_fftsize, 6.76);
+    d_window = gr::fft::window::build((gr::fft::window::win_type)d_wintype, d_fftsize, 6.76);
 }
 
 /*! \brief Get currently used window type. */

--- a/src/dsp/rx_fft.h
+++ b/src/dsp/rx_fft.h
@@ -54,7 +54,7 @@ typedef std::shared_ptr<rx_fft_f> rx_fft_f_sptr;
  * of raw pointers, the rx_fft_c constructor is private.
  * make_rx_fft_c is the public interface for creating new instances.
  */
-rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize=4096, double quad_rate=0, int wintype=gr::filter::firdes::WIN_HAMMING);
+rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize=4096, double quad_rate=0, int wintype=gr::fft::window::WIN_HAMMING);
 
 
 /*! \brief Block for computing complex FFT.
@@ -74,7 +74,7 @@ class rx_fft_c : public gr::sync_block
     friend rx_fft_c_sptr make_rx_fft_c(unsigned int fftsize, double quad_rate, int wintype);
 
 protected:
-    rx_fft_c(unsigned int fftsize=4096, double quad_rate=0, int wintype=gr::filter::firdes::WIN_HAMMING);
+    rx_fft_c(unsigned int fftsize=4096, double quad_rate=0, int wintype=gr::fft::window::WIN_HAMMING);
 
 public:
     ~rx_fft_c();
@@ -123,7 +123,7 @@ private:
  * of raw pointers, the rx_fft_f constructor is private.
  * make_rx_fft_f is the public interface for creating new instances.
  */
-rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize=1024, double audio_rate=48000, int wintype=gr::filter::firdes::WIN_HAMMING);
+rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize=1024, double audio_rate=48000, int wintype=gr::fft::window::WIN_HAMMING);
 
 
 /*! \brief Block for computing real FFT.
@@ -144,7 +144,7 @@ class rx_fft_f : public gr::sync_block
     friend rx_fft_f_sptr make_rx_fft_f(unsigned int fftsize, double audio_rate, int wintype);
 
 protected:
-    rx_fft_f(unsigned int fftsize=1024, double audio_rate=48000, int wintype=gr::filter::firdes::WIN_HAMMING);
+    rx_fft_f(unsigned int fftsize=1024, double audio_rate=48000, int wintype=gr::fft::window::WIN_HAMMING);
 
 public:
     ~rx_fft_f();


### PR DESCRIPTION
Renames to move from filter::firdes to fft::window for GR 3.9.

No thought has been given to how to make this compile for both 3.8 and 3.9, so the PR is not usable yet.

Signed-off-by: Jeff Long <willcode4@gmail.com>