### PR TITLE
Keep custom filter width

### DIFF
--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -31,20 +31,20 @@
 QStringList DockRxOpt::ModulationStrings;
 
 // Filter preset table per mode, preset and lo/hi
-static const int filter_preset_table[DockRxOpt::MODE_LAST][3][2] =
-{   //     WIDE             NORMAL            NARROW
-    {{      0,      0}, {     0,     0}, {     0,     0}},  // MODE_OFF
-    {{ -15000,  15000}, { -5000,  5000}, { -1000,  1000}},  // MODE_RAW
-    {{ -10000,  10000}, { -5000,  5000}, { -2500,  2500}},  // MODE_AM
-    {{ -10000,  10000}, { -5000,  5000}, { -2500,  2500}},  // MODE_NFM
-    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}},  // MODE_WFM_MONO
-    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}},  // MODE_WFM_STEREO
-    {{  -4000,   -100}, { -2800,  -100}, { -2400,  -300}},  // MODE_LSB
-    {{    100,   4000}, {   100,  2800}, {   300,  2400}},  // MODE_USB
-    {{  -1000,   1000}, {  -250,   250}, {  -100,   100}},  // MODE_CWL
-    {{  -1000,   1000}, {  -250,   250}, {  -100,   100}},  // MODE_CWU
-    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}},  // MODE_WFM_STEREO_OIRT
-    {{ -10000,  10000}, { -5000,  5000}, { -2500,  2500}}   // MODE_AMSYNC
+int filter_preset_table[DockRxOpt::MODE_LAST][4][2] =
+{   //     WIDE             NORMAL            NARROW            USER
+    {{      0,      0}, {     0,     0}, {     0,     0}, {     0,     0}},  // MODE_OFF
+    {{ -15000,  15000}, { -5000,  5000}, { -1000,  1000}, { -5000,  5000}},  // MODE_RAW
+    {{ -10000,  10000}, { -5000,  5000}, { -2500,  2500}, { -5000,  5000}},  // MODE_AM
+    {{ -10000,  10000}, { -5000,  5000}, { -2500,  2500}, { -5000,  5000}},  // MODE_NFM
+    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}, {-80000, 80000}},  // MODE_WFM_MONO
+    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}, {-80000, 80000}},  // MODE_WFM_STEREO
+    {{  -4000,   -100}, { -2800,  -100}, { -2400,  -300}, { -2800,  -100}},  // MODE_LSB
+    {{    100,   4000}, {   100,  2800}, {   300,  2400}, {   100,  2800}},  // MODE_USB
+    {{  -1000,   1000}, {  -250,   250}, {  -100,   100}, {  -250,   250}},  // MODE_CWL
+    {{  -1000,   1000}, {  -250,   250}, {  -100,   100}, {  -250,   250}},  // MODE_CWU
+    {{-100000, 100000}, {-80000, 80000}, {-60000, 60000}, {-80000, 80000}},  // MODE_WFM_STEREO_OIRT
+    {{ -10000,  10000}, { -5000,  5000}, { -2500,  2500}, { -5000,  5000}}   // MODE_AMSYNC
 };
 
 DockRxOpt::DockRxOpt(qint64 filterOffsetRange, QWidget *parent) :
@@ -265,10 +265,6 @@ void DockRxOpt::setFilterParam(int lo, int hi)
         width_f = fabs((hi-lo)/1000.f);
         ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)")
                                      .arg(width_f));
-
-        // Save user filter settings 
-        user_filter_lo = lo;
-        user_filter_hi = hi;
     }
 }
 
@@ -375,15 +371,9 @@ void DockRxOpt::getFilterPreset(int mode, int preset, int * lo, int * hi) const
         qDebug() << __func__ << ": Invalid preset:" << preset;
         preset = FILTER_PRESET_NORMAL;
     }
-    else if (preset == 3)
-    {
-        *lo = user_filter_lo;
-        *hi = user_filter_hi;
-    }
-    else {
-        *lo = filter_preset_table[mode][preset][0];
-        *hi = filter_preset_table[mode][preset][1];
-    }
+    
+    *lo = filter_preset_table[mode][preset][0];
+    *hi = filter_preset_table[mode][preset][1];
 }
 
 int DockRxOpt::getCwOffset() const

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -265,6 +265,10 @@ void DockRxOpt::setFilterParam(int lo, int hi)
         width_f = fabs((hi-lo)/1000.f);
         ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)")
                                      .arg(width_f));
+
+        // Save user filter settings 
+        user_filter_lo = lo;
+        user_filter_hi = hi;
     }
 }
 
@@ -366,13 +370,20 @@ void DockRxOpt::getFilterPreset(int mode, int preset, int * lo, int * hi) const
         qDebug() << __func__ << ": Invalid mode:" << mode;
         mode = MODE_AM;
     }
-    else if (preset < 0 || preset > 2)
+    else if (preset < 0 || preset > 3)
     {
         qDebug() << __func__ << ": Invalid preset:" << preset;
         preset = FILTER_PRESET_NORMAL;
     }
-    *lo = filter_preset_table[mode][preset][0];
-    *hi = filter_preset_table[mode][preset][1];
+    else if (preset == 3)
+    {
+        *lo = user_filter_lo;
+        *hi = user_filter_hi;
+    }
+    else {
+        *lo = filter_preset_table[mode][preset][0];
+        *hi = filter_preset_table[mode][preset][1];
+    }
 }
 
 int DockRxOpt::getCwOffset() const

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -370,7 +370,7 @@ void DockRxOpt::getFilterPreset(int mode, int preset, int * lo, int * hi) const
         qDebug() << __func__ << ": Invalid mode:" << mode;
         mode = MODE_AM;
     }
-    else if (preset < 0 || preset > 3)
+    if (preset < 0 || preset > 3)
     {
         qDebug() << __func__ << ": Invalid preset:" << preset;
         preset = FILTER_PRESET_NORMAL;

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -604,10 +604,23 @@ void DockRxOpt::on_filterCombo_activated(int index)
  * Note that the modes listed in the selector are different from those defined by
  * receiver::demod (we want to list LSB/USB separately but they have identical demods).
  */
-void DockRxOpt::on_modeSelector_activated(int index)
+void DockRxOpt::on_modeSelector_activated(int mode_index)
 {
-    updateDemodOptPage(index);
-    emit demodSelected(index);
+    updateDemodOptPage(mode_index);
+
+    // Update the text on the filter selector if using the User preset,
+    // as each mode has a different User filter width
+    auto filter_index =  ui->filterCombo->currentIndex();
+    if (filter_index == FILTER_PRESET_USER)
+    {
+        int hi = filter_preset_table[mode_index][FILTER_PRESET_USER][0];
+        int lo = filter_preset_table[mode_index][FILTER_PRESET_USER][1];
+        float width_f = fabs((hi-lo)/1000.f);
+        ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)")
+                                     .arg(width_f));
+    }
+
+    emit demodSelected(mode_index);
 }
 
 void DockRxOpt::updateDemodOptPage(int demod)

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -265,6 +265,10 @@ void DockRxOpt::setFilterParam(int lo, int hi)
         width_f = fabs((hi-lo)/1000.f);
         ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)")
                                      .arg(width_f));
+
+        int mode_index = ui->modeSelector->currentIndex();
+        filter_preset_table[mode_index][FILTER_PRESET_USER][0] = lo;
+        filter_preset_table[mode_index][FILTER_PRESET_USER][1] = hi;
     }
 }
 

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -606,8 +606,6 @@ void DockRxOpt::on_filterCombo_activated(int index)
  */
 void DockRxOpt::on_modeSelector_activated(int mode_index)
 {
-    updateDemodOptPage(mode_index);
-
     // Update the text on the filter selector if using the User preset,
     // as each mode has a different User filter width
     auto filter_index =  ui->filterCombo->currentIndex();
@@ -620,6 +618,7 @@ void DockRxOpt::on_modeSelector_activated(int mode_index)
                                      .arg(width_f));
     }
 
+    updateDemodOptPage(mode_index);
     emit demodSelected(mode_index);
 }
 

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -246,6 +246,8 @@ private:
     CNbOptions    *nbOpt;     /** Noise blanker options. */
 
     bool agc_is_on;
+    int user_filter_lo = 0;
+    int user_filter_hi = 0;
 
     qint64 hw_freq_hz;   /** Current PLL frequency in Hz. */
 };

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -246,8 +246,6 @@ private:
     CNbOptions    *nbOpt;     /** Noise blanker options. */
 
     bool agc_is_on;
-    int user_filter_lo = 0;
-    int user_filter_hi = 0;
 
     qint64 hw_freq_hz;   /** Current PLL frequency in Hz. */
 };


### PR DESCRIPTION
Fixes #908. Now the custom filter width is kept when changing filter shape. The custom filter width is stored separately for each demod, and switching between demod with the User filter width selected will recall the previously set filter widths for the new demod. These custom filter widths are not yet stored in the settings.