### PR TITLE
CMakeLists.txt: fix macOS HomeBrew icu4c issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,15 @@ if(APPLE AND EXISTS /usr/local/opt/qt5)
     list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
 endif()
 
+if(APPLE AND EXISTS /usr/local/opt/icu4c/lib)
+    # With Homebrew icu4c, `-licudata -licui18n -licuuc`
+    # are required, which reside in /usr/local/opt/icu4c/lib.
+    # See src/CMakeFiles/gqrx.dir/link.txt in the build directory.
+    set(ICU4C_LIBRARY_DIRS "/usr/local/opt/icu4c/lib")
+else()
+    set(ICU4C_LIBRARY_DIRS "")
+endif()
+
 # 3rd Party Dependency Stuff
 find_package(Qt5 COMPONENTS Core Network Widgets Svg REQUIRED)
 find_package(Gnuradio-osmosdr REQUIRED)
@@ -242,6 +251,7 @@ include_directories(
 link_directories(
     ${Boost_LIBRARY_DIRS}
     ${GNURADIO_RUNTIME_LIBRARY_DIRS}
+    ${ICU4C_LIBRARY_DIRS}
 )
 
 


### PR DESCRIPTION
This pull request solves the link error for macOS as:
```
[100%] Linking CXX executable gqrx
ld: library not found for -licudata
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/gqrx] Error 1
make[1]: *** [src/CMakeFiles/gqrx.dir/all] Error 2
make: *** [all] Error 2
```

Tested on macOS 10.15.7 with Xcode 12.3 and HomeBrew icu4c.