### PR TITLE
Changing filter shape resets custom filter width to "normal" #908

### DIFF
--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2147,18 +2147,18 @@ void MainWindow::onBookmarkActivated(qint64 freq, const QString& demod, int band
     int lo, hi;
     uiDockRxOpt->getFilterPreset(mode, preset, &lo, &hi);
 
-    if(lo + hi == 0)
-    {
-        lo = -bandwidth / 2;
-        hi =  bandwidth / 2;
-    }
-    else if(lo >= 0 && hi >= 0)
+    if(lo >= 0 && hi >= 0) // USB
     {
         hi = lo + bandwidth;
     }
-    else if(lo <= 0 && hi <= 0)
+    else if(lo <= 0 && hi <= 0) // LSB
     {
         lo = hi - bandwidth;
+    }
+    else  // symmetric and anything else
+    {
+        lo = -bandwidth / 2;
+        hi =  bandwidth / 2;
     }
 
     on_plotter_newFilterFreq(lo, hi);
@@ -2173,18 +2173,18 @@ void MainWindow::setPassband(int bandwidth)
     int lo, hi;
     uiDockRxOpt->getFilterPreset(mode, preset, &lo, &hi);
 
-    if(lo + hi == 0)
-    {
-        lo = -bandwidth / 2;
-        hi =  bandwidth / 2;
-    }
-    else if(lo >= 0 && hi >= 0)
+    if(lo >= 0 && hi >= 0) // USB
     {
         hi = lo + bandwidth;
     }
-    else if(lo <= 0 && hi <= 0)
+    else if(lo <= 0 && hi <= 0) // LSB
     {
         lo = hi - bandwidth;
+    }
+    else  // symmetric and anything else
+    {
+        lo = -bandwidth / 2;
+        hi =  bandwidth / 2;
     }
 
     remote->setPassband(lo, hi);

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2137,6 +2137,10 @@ void MainWindow::setRdsDecoder(bool checked)
 
 void MainWindow::onBookmarkActivated(qint64 freq, const QString& demod, int bandwidth)
 {
+    // set RX filter
+    rx->set_filter_offset(0);
+    // update RF freq label and channel filter offset
+    uiDockRxOpt->setFilterOffset(0);
     setNewFrequency(freq);
     selectDemod(demod);
 
@@ -2162,6 +2166,7 @@ void MainWindow::onBookmarkActivated(qint64 freq, const QString& demod, int band
     }
 
     on_plotter_newFilterFreq(lo, hi);
+    ui->plotter ->moveToCenterFreq();
 }
 
 void MainWindow::setPassband(int bandwidth)

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2151,11 +2151,11 @@ void MainWindow::onBookmarkActivated(qint64 freq, const QString& demod, int band
     int lo, hi;
     uiDockRxOpt->getFilterPreset(mode, preset, &lo, &hi);
 
-    if(lo >= 0 && hi >= 0 && mode == DockRxOpt::MODE_USB) // USB
+    if(lo >= 0 && hi >= 0) // USB
     {
         hi = lo + bandwidth;
     }
-    else if(lo <= 0 && hi <= 0 && mode == DockRxOpt::MODE_LSB) // LSB
+    else if(lo <= 0 && hi <= 0) // LSB
     {
         lo = hi - bandwidth;
     }

--- a/src/applications/gqrx/mainwindow.cpp
+++ b/src/applications/gqrx/mainwindow.cpp
@@ -2151,11 +2151,11 @@ void MainWindow::onBookmarkActivated(qint64 freq, const QString& demod, int band
     int lo, hi;
     uiDockRxOpt->getFilterPreset(mode, preset, &lo, &hi);
 
-    if(lo >= 0 && hi >= 0) // USB
+    if(lo >= 0 && hi >= 0 && mode == DockRxOpt::MODE_USB) // USB
     {
         hi = lo + bandwidth;
     }
-    else if(lo <= 0 && hi <= 0) // LSB
+    else if(lo <= 0 && hi <= 0 && mode == DockRxOpt::MODE_LSB) // LSB
     {
         lo = hi - bandwidth;
     }

--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -261,10 +261,12 @@ void DockRxOpt::setFilterParam(int lo, int hi)
     ui->filterCombo->setCurrentIndex(filter_index);
     if (filter_index == FILTER_PRESET_USER)
     {
+        glo = lo;
+        ghi = hi;
         float width_f;
         width_f = fabs((hi-lo)/1000.f);
-        ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)")
-                                     .arg(width_f));
+        ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)").arg(width_f));
+        qobject_cast<QStandardItemModel*>(ui->filterCombo->model())->item(3)->setEnabled(true);
     }
 }
 
@@ -366,13 +368,22 @@ void DockRxOpt::getFilterPreset(int mode, int preset, int * lo, int * hi) const
         qDebug() << __func__ << ": Invalid mode:" << mode;
         mode = MODE_AM;
     }
-    else if (preset < 0 || preset > 2)
+    else if (preset < 0 || preset > 3)
     {
         qDebug() << __func__ << ": Invalid preset:" << preset;
         preset = FILTER_PRESET_NORMAL;
     }
+
+    if (preset == 3)
+    {
+    *lo = glo;
+    *hi = ghi;
+    }
+    else
+    {
     *lo = filter_preset_table[mode][preset][0];
     *hi = filter_preset_table[mode][preset][1];
+    }
 }
 
 int DockRxOpt::getCwOffset() const
@@ -383,6 +394,10 @@ int DockRxOpt::getCwOffset() const
 /** Read receiver configuration from settings data. */
 void DockRxOpt::readSettings(QSettings *settings)
 {
+
+    /** Disable Customfield in filterCombo. */
+    qobject_cast<QStandardItemModel*>(ui->filterCombo->model())->item(3)->setEnabled(false);
+    
     bool    conv_ok;
     int     int_val;
     double  dbl_val;

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -246,6 +246,7 @@ private:
     CNbOptions    *nbOpt;     /** Noise blanker options. */
 
     bool agc_is_on;
+    int glo, ghi = 0;
 
     qint64 hw_freq_hz;   /** Current PLL frequency in Hz. */
 };


### PR DESCRIPTION
for #908

This is the second pull request because I accidentally cited my master as the source for the first one ... I apologize for that - as a newcomer to github I still have some problems ... If I read that correctly, I can now set the first wrong pull request to done and the problem is eliminated.