### PR TITLE
second try for #908

### DIFF
--- a/src/qtgui/dockrxopt.cpp
+++ b/src/qtgui/dockrxopt.cpp
@@ -262,9 +262,11 @@ void DockRxOpt::setFilterParam(int lo, int hi)
     if (filter_index == FILTER_PRESET_USER)
     {
         float width_f;
+        glo = lo;
+        ghi = hi;
         width_f = fabs((hi-lo)/1000.f);
-        ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)")
-                                     .arg(width_f));
+        ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User (%1 k)").arg(width_f));
+        qobject_cast<QStandardItemModel*>(ui->filterCombo->model())->item(3)->setEnabled(true);
     }
 }
 
@@ -366,13 +368,22 @@ void DockRxOpt::getFilterPreset(int mode, int preset, int * lo, int * hi) const
         qDebug() << __func__ << ": Invalid mode:" << mode;
         mode = MODE_AM;
     }
-    else if (preset < 0 || preset > 2)
+    else if (preset < 0 || preset > 3)
     {
         qDebug() << __func__ << ": Invalid preset:" << preset;
         preset = FILTER_PRESET_NORMAL;
     }
+
+    if (preset == 3)
+    {
+    *lo = glo;
+    *hi = ghi;
+    }
+    else
+    {
     *lo = filter_preset_table[mode][preset][0];
     *hi = filter_preset_table[mode][preset][1];
+    }
 }
 
 int DockRxOpt::getCwOffset() const
@@ -383,6 +394,8 @@ int DockRxOpt::getCwOffset() const
 /** Read receiver configuration from settings data. */
 void DockRxOpt::readSettings(QSettings *settings)
 {
+    /** Disable Customfield in filterCombo. */
+    qobject_cast <QStandardItemModel *> (ui-> filterCombo-> model ()) -> item (3) -> setEnabled (false);
     bool    conv_ok;
     int     int_val;
     double  dbl_val;
@@ -602,6 +615,11 @@ void DockRxOpt::on_filterCombo_activated(int index)
 void DockRxOpt::on_modeSelector_activated(int index)
 {
     updateDemodOptPage(index);
+    ui->filterCombo->setCurrentIndex(1);
+    ui->filterCombo->setItemText(FILTER_PRESET_USER, QString("User"));
+    qobject_cast <QStandardItemModel *> (ui-> filterCombo-> model ()) -> item (3) -> setEnabled (false);
+    glo = 0;
+    ghi = 0;
     emit demodSelected(index);
 }
 

--- a/src/qtgui/dockrxopt.h
+++ b/src/qtgui/dockrxopt.h
@@ -246,6 +246,7 @@ private:
     CNbOptions    *nbOpt;     /** Noise blanker options. */
 
     bool agc_is_on;
+    int glo, ghi = 0;
 
     qint64 hw_freq_hz;   /** Current PLL frequency in Hz. */
 };


### PR DESCRIPTION
I reconsidered the whole thing and the changes I have made so far have been plain garbage.

The procedure was wrong from the start because it makes sense to switch to normal bandwidth at least when changing the demodulator. A user bandwidth for USB makes no sense with AM or FM. As far as I understand the code, filter shape and mode use the same slot and you can no longer tell who has emitted something.

Here is my new attempt to fix the "error" - Filterwidth gets stuck in the user even though it was switched to normal. In addition, only changing the demodulator and not longer changing the filter shape is switching to normal.

The user filter remains active and selectable as long as the demodulator mode is not changed. If it is changed, the user filter is set to zero and switched off until a new user bandwidth is set with the current demodulator mode.